### PR TITLE
Fix commitlint type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,11 @@
   "devDependencies": {
     "@antfu/eslint-config": "^6.2.0",
     "@chromatic-com/playwright": "^0.12.7",
+    "@clerk/types": "^4.101.6",
     "@commitlint/cli": "^20.1.0",
     "@commitlint/config-conventional": "^20.0.0",
     "@commitlint/prompt-cli": "^20.1.0",
+    "@commitlint/types": "^20.2.0",
     "@electric-sql/pglite-socket": "^0.0.19",
     "@eslint-react/eslint-plugin": "^2.3.5",
     "@faker-js/faker": "^10.1.0",
@@ -113,6 +115,7 @@
     "tailwindcss": "^4.1.17",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
+    "vite": "^7.2.7",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.0.4",
     "vitest-browser-react": "^2.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@chromatic-com/playwright':
         specifier: ^0.12.7
         version: 0.12.8(@playwright/test@1.57.0)(@swc/core@1.15.3)(@types/react@19.2.7)(esbuild@0.25.12)(prettier@3.7.4)(typescript@5.9.3)
+      '@clerk/types':
+        specifier: ^4.101.6
+        version: 4.101.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@commitlint/cli':
         specifier: ^20.1.0
         version: 20.2.0(@types/node@24.10.3)(typescript@5.9.3)
@@ -108,6 +111,9 @@ importers:
       '@commitlint/prompt-cli':
         specifier: ^20.1.0
         version: 20.2.0(@types/node@24.10.3)(typescript@5.9.3)
+      '@commitlint/types':
+        specifier: ^20.2.0
+        version: 20.2.0
       '@electric-sql/pglite-socket':
         specifier: ^0.0.19
         version: 0.0.19(@electric-sql/pglite@0.3.14)
@@ -243,6 +249,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vite:
+        specifier: ^7.2.7
+        version: 7.2.7(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@7.2.7(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
@@ -10194,7 +10203,7 @@ snapshots:
     dependencies:
       is-negated-glob: 1.0.0
 
-  '@hono/mcp@0.1.5(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(hono@4.10.8)':
+  '@hono/mcp@0.1.5(@modelcontextprotocol/sdk@1.24.3(zod@4.1.13))(hono@4.10.8)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)
       hono: 4.10.8
@@ -11650,7 +11659,7 @@ snapshots:
 
   '@spotlightjs/spotlight@4.7.2':
     dependencies:
-      '@hono/mcp': 0.1.5(@modelcontextprotocol/sdk@1.24.3(zod@3.25.76))(hono@4.10.8)
+      '@hono/mcp': 0.1.5(@modelcontextprotocol/sdk@1.24.3(zod@4.1.13))(hono@4.10.8)
       '@hono/node-server': 1.19.7(hono@4.10.8)
       '@jridgewell/trace-mapping': 0.3.31
       '@modelcontextprotocol/sdk': 1.24.3(zod@3.25.76)

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,46 +1,46 @@
-import type { Metadata } from "next";
+import type { Metadata } from 'next';
 
-import { GeistMono } from "geist/font/mono";
-import { GeistSans } from "geist/font/sans";
-import { hasLocale, NextIntlClientProvider } from "next-intl";
-import { getTranslations, setRequestLocale } from "next-intl/server";
-import { headers } from "next/headers";
-import Link from "next/link";
-import { notFound } from "next/navigation";
+import { GeistMono } from 'geist/font/mono';
+import { GeistSans } from 'geist/font/sans';
+import { hasLocale, NextIntlClientProvider } from 'next-intl';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { headers } from 'next/headers';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
-import { PostHogProvider } from "@/components/analytics/PostHogProvider";
-import { LocaleSwitcher } from "@/components/LocaleSwitcher";
-import { routing } from "@/libs/I18nRouting";
-import { BaseTemplate } from "@/templates/BaseTemplate";
-import "@/styles/global.css";
+import { PostHogProvider } from '@/components/analytics/PostHogProvider';
+import { LocaleSwitcher } from '@/components/LocaleSwitcher';
+import { routing } from '@/libs/I18nRouting';
+import { BaseTemplate } from '@/templates/BaseTemplate';
+import '@/styles/global.css';
 
 export const metadata: Metadata = {
   icons: [
     {
-      rel: "apple-touch-icon",
-      url: "/apple-touch-icon.png",
+      rel: 'apple-touch-icon',
+      url: '/apple-touch-icon.png',
     },
     {
-      rel: "icon",
-      type: "image/png",
-      sizes: "32x32",
-      url: "/favicon-32x32.png",
+      rel: 'icon',
+      type: 'image/png',
+      sizes: '32x32',
+      url: '/favicon-32x32.png',
     },
     {
-      rel: "icon",
-      type: "image/png",
-      sizes: "16x16",
-      url: "/favicon-16x16.png",
+      rel: 'icon',
+      type: 'image/png',
+      sizes: '16x16',
+      url: '/favicon-16x16.png',
     },
     {
-      rel: "icon",
-      url: "/favicon.ico",
+      rel: 'icon',
+      url: '/favicon.ico',
     },
   ],
 };
 
 export function generateStaticParams() {
-  return routing.locales.map((locale) => ({ locale }));
+  return routing.locales.map(locale => ({ locale }));
 }
 
 export default async function RootLayout(props: {
@@ -56,22 +56,22 @@ export default async function RootLayout(props: {
   setRequestLocale(locale);
   const t = await getTranslations({
     locale,
-    namespace: "RootLayout",
+    namespace: 'RootLayout',
   });
 
   // Check if we're on a marketing route (routes that use dashboard sidebar)
   const headersList = await headers();
-  const pathname = headersList.get("x-pathname") || "";
-  const isMarketingRoute =
-    pathname === "/" ||
-    pathname === "/about/" ||
-    pathname === "/about" ||
-    pathname.startsWith("/content/") ||
+  const pathname = headersList.get('x-pathname') || '';
+  const isMarketingRoute
+    = pathname === '/'
+      || pathname === '/about/'
+      || pathname === '/about'
+      || pathname.startsWith('/content/')
     // Add locale prefix variations
-    pathname.match(/^\/[a-z]{2}$/) ||
-    pathname.match(/^\/[a-z]{2}\/$/) ||
-    pathname.match(/^\/[a-z]{2}\/about/) ||
-    pathname.match(/^\/[a-z]{2}\/content/);
+      || pathname.match(/^\/[a-z]{2}$/)
+      || pathname.match(/^\/[a-z]{2}\/$/)
+      || pathname.match(/^\/[a-z]{2}\/about/)
+      || pathname.match(/^\/[a-z]{2}\/content/);
 
   return (
     <html
@@ -81,77 +81,79 @@ export default async function RootLayout(props: {
       <body className="font-sans antialiased">
         <NextIntlClientProvider>
           <PostHogProvider>
-            {isMarketingRoute ? (
-              // Marketing routes: render children directly (they have their own layout with sidebar)
-              <div>{props.children}</div>
-            ) : (
-              // Other routes: use BaseTemplate with navigation
-              <BaseTemplate
-                leftNav={
-                  <>
-                    <li>
-                      <Link
-                        href="/"
-                        className="border-none text-gray-700 hover:text-gray-900"
-                      >
-                        {t("home_link")}
-                      </Link>
-                    </li>
-                    <li>
-                      <Link
-                        href="/about/"
-                        className="border-none text-gray-700 hover:text-gray-900"
-                      >
-                        {t("about_link")}
-                      </Link>
-                    </li>
-                    <li>
-                      <Link
-                        href="/portfolio/"
-                        className="border-none text-gray-700 hover:text-gray-900"
-                      >
-                        {t("portfolio_link")}
-                      </Link>
-                    </li>
-                    <li>
-                      <a
-                        className="border-none text-gray-700 hover:text-gray-900"
-                        href="https://github.com/ixartz/Next-js-Boilerplate"
-                      >
-                        GitHub
-                      </a>
-                    </li>
-                  </>
-                }
-                rightNav={
-                  <>
-                    <li>
-                      <Link
-                        href="/sign-in/"
-                        className="border-none text-gray-700 hover:text-gray-900"
-                      >
-                        {t("sign_in_link")}
-                      </Link>
-                    </li>
+            {isMarketingRoute
+              ? (
+                // Marketing routes: render children directly (they have their own layout with sidebar)
+                  <div>{props.children}</div>
+                )
+              : (
+                // Other routes: use BaseTemplate with navigation
+                  <BaseTemplate
+                    leftNav={(
+                      <>
+                        <li>
+                          <Link
+                            href="/"
+                            className="border-none text-gray-700 hover:text-gray-900"
+                          >
+                            {t('home_link')}
+                          </Link>
+                        </li>
+                        <li>
+                          <Link
+                            href="/about/"
+                            className="border-none text-gray-700 hover:text-gray-900"
+                          >
+                            {t('about_link')}
+                          </Link>
+                        </li>
+                        <li>
+                          <Link
+                            href="/portfolio/"
+                            className="border-none text-gray-700 hover:text-gray-900"
+                          >
+                            {t('portfolio_link')}
+                          </Link>
+                        </li>
+                        <li>
+                          <a
+                            className="border-none text-gray-700 hover:text-gray-900"
+                            href="https://github.com/ixartz/Next-js-Boilerplate"
+                          >
+                            GitHub
+                          </a>
+                        </li>
+                      </>
+                    )}
+                    rightNav={(
+                      <>
+                        <li>
+                          <Link
+                            href="/sign-in/"
+                            className="border-none text-gray-700 hover:text-gray-900"
+                          >
+                            {t('sign_in_link')}
+                          </Link>
+                        </li>
 
-                    <li>
-                      <Link
-                        href="/sign-up/"
-                        className="border-none text-gray-700 hover:text-gray-900"
-                      >
-                        {t("sign_up_link")}
-                      </Link>
-                    </li>
+                        <li>
+                          <Link
+                            href="/sign-up/"
+                            className="border-none text-gray-700 hover:text-gray-900"
+                          >
+                            {t('sign_up_link')}
+                          </Link>
+                        </li>
 
-                    <li>
-                      <LocaleSwitcher />
-                    </li>
-                  </>
-                }
-              >
-                <div className="py-5 text-xl [&_p]:my-6">{props.children}</div>
-              </BaseTemplate>
-            )}
+                        <li>
+                          <LocaleSwitcher />
+                        </li>
+                      </>
+                    )}
+                  >
+                    <div className="py-5 text-xl [&_p]:my-6">{props.children}</div>
+                  </BaseTemplate>
+                )}
           </PostHogProvider>
         </NextIntlClientProvider>
       </body>


### PR DESCRIPTION
Add missing type definition packages to `devDependencies` and fix linting issues to resolve Vercel build failures.

The Vercel build was failing due to TypeScript compilation errors because `@commitlint/types`, `@clerk/types`, and `vite` were referenced in type imports but were not installed as devDependencies. This PR adds these missing packages and addresses minor linting issues for code style consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ca62a4a-b0f8-4274-8f7a-c880f949ab46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ca62a4a-b0f8-4274-8f7a-c880f949ab46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

