### PR TITLE
fix: set theme-color meta tag to match dark background

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -37,6 +37,7 @@ export const metadata: Metadata = {
       url: '/favicon.ico',
     },
   ],
+  themeColor: '#0a090c',
 };
 
 export function generateStaticParams() {


### PR DESCRIPTION
Add themeColor to Next.js metadata to match the dark off-black
background color (#0a090c), ensuring browser chrome and mobile
address bars display the correct color.