### PR TITLE
feat: set default feed tabs for home and dashboard pages

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/page.tsx
+++ b/src/app/[locale]/(auth)/dashboard/page.tsx
@@ -1,11 +1,11 @@
-import type { Metadata } from 'next';
-import { getTranslations } from 'next-intl/server';
-import { DiscoverGrid } from '@/components/discover-grid';
-import { Env } from '@/libs/Env';
-import { getSupabaseAdmin } from '@/libs/Supabase';
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { DiscoverGrid } from "@/components/discover-grid";
+import { Env } from "@/libs/Env";
+import { getSupabaseAdmin } from "@/libs/Supabase";
 
 // Force dynamic rendering since this page requires user-specific data
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
@@ -13,11 +13,11 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const t = await getTranslations({
     locale,
-    namespace: 'Dashboard',
+    namespace: "Dashboard",
   });
 
   return {
-    title: t('meta_title'),
+    title: t("meta_title"),
   };
 }
 
@@ -49,7 +49,7 @@ export default async function Dashboard(props: {
 
   // Fetch content items with categories and audio files
   const { data: contentItems, error } = await supabase
-    .from('content_items')
+    .from("content_items")
     .select(
       `
       id,
@@ -71,8 +71,8 @@ export default async function Dashboard(props: {
       )
     `,
     )
-    .eq('status', 'done')
-    .order('created_at', { ascending: false })
+    .eq("status", "done")
+    .order("created_at", { ascending: false })
     .limit(50);
 
   if (error) {
@@ -110,7 +110,7 @@ export default async function Dashboard(props: {
     }
 
     // Get category from tags, or fall back to content_sources.name, or default to "Uncategorized"
-    let categoryName = 'Uncategorized';
+    let categoryName = "Uncategorized";
     const firstTag = item.content_item_tags?.[0] as any;
     if (firstTag?.categories?.name) {
       categoryName = firstTag.categories.name;
@@ -183,7 +183,11 @@ export default async function Dashboard(props: {
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 md:px-6 lg:px-8">
-      <DiscoverGrid categories={categories} locale={locale} />
+      <DiscoverGrid
+        categories={categories}
+        locale={locale}
+        surface="dashboard"
+      />
     </div>
   );
 }

--- a/src/app/[locale]/(marketing)/content/[id]/page.tsx
+++ b/src/app/[locale]/(marketing)/content/[id]/page.tsx
@@ -1,12 +1,12 @@
-import type { Metadata } from 'next';
-import { getTranslations } from 'next-intl/server';
-import { notFound } from 'next/navigation';
-import { ContentDetailView } from '@/components/content-detail-view';
-import { Env } from '@/libs/Env';
-import { getSupabaseAdmin } from '@/libs/Supabase';
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+import { ContentDetailView } from "@/components/content-detail-view";
+import { Env } from "@/libs/Env";
+import { getSupabaseAdmin } from "@/libs/Supabase";
 
 // Force dynamic rendering
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 type ContentDetailProps = {
   params: Promise<{ id: string; locale: string }>;
@@ -22,25 +22,25 @@ export async function generateMetadata(
 
   if (!hasSupabaseUrl || !hasSupabaseKey) {
     return {
-      title: 'Content Not Available',
+      title: "Content Not Available",
     };
   }
 
   const supabase = getSupabaseAdmin();
   const { data: item } = await supabase
-    .from('content_items')
-    .select('title')
-    .eq('id', id)
+    .from("content_items")
+    .select("title")
+    .eq("id", id)
     .single();
 
   const t = await getTranslations({
     locale,
-    namespace: 'Dashboard',
+    namespace: "Dashboard",
   });
 
   return {
-    title: item?.title || t('meta_title'),
-    description: item?.title || 'Content detail',
+    title: item?.title || t("meta_title"),
+    description: item?.title || "Content detail",
   };
 }
 
@@ -65,7 +65,7 @@ export default async function ContentDetail(props: ContentDetailProps) {
 
   // Fetch the content item with all related data
   const { data: item, error } = await supabase
-    .from('content_items')
+    .from("content_items")
     .select(
       `
       id,
@@ -90,8 +90,8 @@ export default async function ContentDetail(props: ContentDetailProps) {
       )
     `,
     )
-    .eq('id', id)
-    .eq('status', 'done')
+    .eq("id", id)
+    .eq("status", "done")
     .single();
 
   if (error || !item) {
@@ -99,7 +99,7 @@ export default async function ContentDetail(props: ContentDetailProps) {
   }
 
   // Get category from tags or content source
-  let categoryName = 'Uncategorized';
+  let categoryName = "Uncategorized";
   const firstTag = item.content_item_tags?.[0] as any;
   if (firstTag?.categories?.name) {
     categoryName = firstTag.categories.name;
@@ -132,5 +132,7 @@ export default async function ContentDetail(props: ContentDetailProps) {
     createdAt: item.created_at,
   };
 
-  return <ContentDetailView content={contentData} locale={locale} />;
+  return (
+    <ContentDetailView content={contentData} locale={locale} surface="home" />
+  );
 }

--- a/src/app/[locale]/(marketing)/page.tsx
+++ b/src/app/[locale]/(marketing)/page.tsx
@@ -1,11 +1,11 @@
-import type { Metadata } from 'next';
-import { getTranslations } from 'next-intl/server';
-import { ContentGridDiscover } from '@/components/content-grid-discover';
-import { Env } from '@/libs/Env';
-import { getSupabaseAdmin } from '@/libs/Supabase';
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { ContentGridDiscover } from "@/components/content-grid-discover";
+import { Env } from "@/libs/Env";
+import { getSupabaseAdmin } from "@/libs/Supabase";
 
 // Force dynamic rendering since this page requires user-specific data
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
@@ -13,11 +13,11 @@ export async function generateMetadata(props: {
   const { locale } = await props.params;
   const t = await getTranslations({
     locale,
-    namespace: 'Dashboard',
+    namespace: "Dashboard",
   });
 
   return {
-    title: t('meta_title'),
+    title: t("meta_title"),
   };
 }
 
@@ -49,7 +49,7 @@ export default async function Dashboard(props: {
 
   // Fetch content items with categories and audio files
   const { data: contentItems, error } = await supabase
-    .from('content_items')
+    .from("content_items")
     .select(
       `
       id,
@@ -71,8 +71,8 @@ export default async function Dashboard(props: {
       )
     `,
     )
-    .eq('status', 'done')
-    .order('created_at', { ascending: false })
+    .eq("status", "done")
+    .order("created_at", { ascending: false })
     .limit(50);
 
   if (error) {
@@ -110,7 +110,7 @@ export default async function Dashboard(props: {
     }
 
     // Get category from tags, or fall back to content_sources.name, or default to "Uncategorized"
-    let categoryName = 'Uncategorized';
+    let categoryName = "Uncategorized";
     const firstTag = item.content_item_tags?.[0] as any;
     if (firstTag?.categories?.name) {
       categoryName = firstTag.categories.name;
@@ -183,7 +183,11 @@ export default async function Dashboard(props: {
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 md:px-6 lg:px-8">
-      <ContentGridDiscover categories={categories} locale={locale} />
+      <ContentGridDiscover
+        categories={categories}
+        locale={locale}
+        surface="home"
+      />
     </div>
   );
 }

--- a/src/components/content-detail-view.tsx
+++ b/src/components/content-detail-view.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import { motion } from 'framer-motion';
+import { motion } from "framer-motion";
 import {
   ArrowLeft,
   Calendar,
@@ -10,11 +10,12 @@ import {
   Play,
   SkipBack,
   SkipForward,
-} from 'lucide-react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useEffect, useRef, useState } from 'react';
-import { cn } from '@/libs/utils';
+} from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/libs/utils";
+import { useContentAnalytics } from "@/hooks/useContentAnalytics";
 
 type ContentDetailViewProps = {
   content: {
@@ -32,32 +33,44 @@ type ContentDetailViewProps = {
     createdAt: string;
   };
   locale: string;
+  surface?: "home" | "dashboard";
+  userId?: string;
+  experimentVariant?: string;
 };
 
-export function ContentDetailView({ content, locale }: ContentDetailViewProps) {
+export function ContentDetailView({
+  content,
+  locale,
+  surface = "home",
+  userId,
+  experimentVariant,
+}: ContentDetailViewProps) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(content.duration || 0);
   const [isLoading, setIsLoading] = useState(false);
   const audioRef = useRef<HTMLAudioElement>(null);
+  const hasTrackedPlayStart = useRef(false);
+  const { trackContentPlayStarted, trackContentPlayCompleted } =
+    useContentAnalytics();
 
   // Format time from seconds to MM:SS
   const formatTime = (seconds: number): string => {
     if (!seconds || !Number.isFinite(seconds)) {
-      return '0:00';
+      return "0:00";
     }
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
   };
 
   // Format date
   const formatDate = (dateString: string): string => {
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
     });
   };
 
@@ -79,6 +92,19 @@ export function ContentDetailView({ content, locale }: ContentDetailViewProps) {
     const handleEnded = () => {
       setIsPlaying(false);
       setCurrentTime(0);
+
+      // Track play completion
+      trackContentPlayCompleted({
+        user_id: userId,
+        content_name: content.title,
+        content_category: content.category,
+        content_id: content.id,
+        surface,
+        experiment_variant: experimentVariant,
+      });
+
+      // Reset play start tracking for next playthrough
+      hasTrackedPlayStart.current = false;
     };
 
     const handleLoadStart = () => {
@@ -89,18 +115,18 @@ export function ContentDetailView({ content, locale }: ContentDetailViewProps) {
       setIsLoading(false);
     };
 
-    audio.addEventListener('timeupdate', handleTimeUpdate);
-    audio.addEventListener('loadedmetadata', handleLoadedMetadata);
-    audio.addEventListener('ended', handleEnded);
-    audio.addEventListener('loadstart', handleLoadStart);
-    audio.addEventListener('canplay', handleCanPlay);
+    audio.addEventListener("timeupdate", handleTimeUpdate);
+    audio.addEventListener("loadedmetadata", handleLoadedMetadata);
+    audio.addEventListener("ended", handleEnded);
+    audio.addEventListener("loadstart", handleLoadStart);
+    audio.addEventListener("canplay", handleCanPlay);
 
     return () => {
-      audio.removeEventListener('timeupdate', handleTimeUpdate);
-      audio.removeEventListener('loadedmetadata', handleLoadedMetadata);
-      audio.removeEventListener('ended', handleEnded);
-      audio.removeEventListener('loadstart', handleLoadStart);
-      audio.removeEventListener('canplay', handleCanPlay);
+      audio.removeEventListener("timeupdate", handleTimeUpdate);
+      audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
+      audio.removeEventListener("ended", handleEnded);
+      audio.removeEventListener("loadstart", handleLoadStart);
+      audio.removeEventListener("canplay", handleCanPlay);
     };
   }, []);
 
@@ -117,6 +143,19 @@ export function ContentDetailView({ content, locale }: ContentDetailViewProps) {
       try {
         await audio.play();
         setIsPlaying(true);
+
+        // Track play start (only once per session)
+        if (!hasTrackedPlayStart.current) {
+          trackContentPlayStarted({
+            user_id: userId,
+            content_name: content.title,
+            content_category: content.category,
+            content_id: content.id,
+            surface,
+            experiment_variant: experimentVariant,
+          });
+          hasTrackedPlayStart.current = true;
+        }
       } catch {
         setIsPlaying(false);
       }
@@ -200,21 +239,19 @@ export function ContentDetailView({ content, locale }: ContentDetailViewProps) {
             {content.sourceName && (
               <div className="flex items-center gap-2">
                 <span>•</span>
-                {content.sourceLink
-                  ? (
-                      <a
-                        href={content.sourceLink}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center gap-1 hover:text-white"
-                      >
-                        {content.sourceName}
-                        <ExternalLink className="h-3 w-3" />
-                      </a>
-                    )
-                  : (
-                      <span>{content.sourceName}</span>
-                    )}
+                {content.sourceLink ? (
+                  <a
+                    href={content.sourceLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 hover:text-white"
+                  >
+                    {content.sourceName}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                ) : (
+                  <span>{content.sourceName}</span>
+                )}
               </div>
             )}
           </div>
@@ -315,9 +352,9 @@ export function ContentDetailView({ content, locale }: ContentDetailViewProps) {
               className="mb-4 h-1 w-full cursor-pointer overflow-hidden rounded-full bg-white/10"
               onClick={handleSeek}
               onKeyDown={(e) => {
-                if (e.key === 'ArrowLeft') {
+                if (e.key === "ArrowLeft") {
                   skipTime(-5);
-                } else if (e.key === 'ArrowRight') {
+                } else if (e.key === "ArrowRight") {
                   skipTime(5);
                 }
               }}
@@ -357,21 +394,19 @@ export function ContentDetailView({ content, locale }: ContentDetailViewProps) {
                   onClick={togglePlay}
                   disabled={isLoading}
                   className={cn(
-                    'flex h-14 w-14 items-center justify-center rounded-full transition-all',
+                    "flex h-14 w-14 items-center justify-center rounded-full transition-all",
                     isPlaying
-                      ? 'bg-white text-black shadow-[0_0_30px_rgba(255,255,255,0.3)]'
-                      : 'bg-white/10 text-white hover:bg-white hover:text-black',
-                    isLoading && 'opacity-50',
+                      ? "bg-white text-black shadow-[0_0_30px_rgba(255,255,255,0.3)]"
+                      : "bg-white/10 text-white hover:bg-white hover:text-black",
+                    isLoading && "opacity-50",
                   )}
-                  aria-label={isPlaying ? 'Pause' : 'Play'}
+                  aria-label={isPlaying ? "Pause" : "Play"}
                 >
-                  {isPlaying
-                    ? (
-                        <Pause className="h-6 w-6 fill-current" />
-                      )
-                    : (
-                        <Play className="ml-1 h-6 w-6 fill-current" />
-                      )}
+                  {isPlaying ? (
+                    <Pause className="h-6 w-6 fill-current" />
+                  ) : (
+                    <Play className="ml-1 h-6 w-6 fill-current" />
+                  )}
                 </motion.button>
 
                 <motion.button

--- a/src/components/content-grid-card.tsx
+++ b/src/components/content-grid-card.tsx
@@ -1,9 +1,10 @@
-'use client';
+"use client";
 
-import { motion } from 'framer-motion';
-import { Clock } from 'lucide-react';
-import Image from 'next/image';
-import Link from 'next/link';
+import { motion } from "framer-motion";
+import { Clock } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { useContentAnalytics } from "@/hooks/useContentAnalytics";
 
 type ContentGridCardProps = {
   id: string;
@@ -14,6 +15,9 @@ type ContentGridCardProps = {
   duration?: number | null;
   index?: number;
   locale: string;
+  surface?: "home" | "dashboard";
+  userId?: string;
+  experimentVariant?: string;
 };
 
 export function ContentGridCard({
@@ -25,22 +29,38 @@ export function ContentGridCard({
   duration,
   index = 0,
   locale,
+  surface = "home",
+  userId,
+  experimentVariant,
 }: ContentGridCardProps) {
+  const { trackContentViewed } = useContentAnalytics();
+
   // Format duration from seconds to MM:SS
   const formatDuration = (seconds: number | null | undefined): string => {
     if (!seconds) {
-      return '0:00';
+      return "0:00";
     }
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
+    return `${mins}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const handleClick = () => {
+    trackContentViewed({
+      user_id: userId,
+      content_name: title,
+      content_category: category,
+      content_id: id,
+      surface,
+      experiment_variant: experimentVariant,
+    });
   };
 
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: '-50px' }}
+      viewport={{ once: true, margin: "-50px" }}
       transition={{
         duration: 0.5,
         delay: index * 0.05,
@@ -50,47 +70,46 @@ export function ContentGridCard({
     >
       <Link
         href={`/${locale}/content/${id}`}
+        onClick={handleClick}
         className="relative block overflow-hidden rounded-2xl border border-white/10 bg-[#0A0A0A] transition-all duration-300 hover:border-white/30 hover:shadow-lg hover:shadow-white/5"
       >
         {/* Image Section */}
-        {imageUrl
-          ? (
-              <div className="relative aspect-[16/9] w-full overflow-hidden">
-                <Image
-                  src={imageUrl}
-                  alt={title}
-                  fill
-                  className="object-cover transition-transform duration-500 group-hover:scale-105"
-                  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-[#0A0A0A] via-transparent to-transparent" />
+        {imageUrl ? (
+          <div className="relative aspect-[16/9] w-full overflow-hidden">
+            <Image
+              src={imageUrl}
+              alt={title}
+              fill
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-[#0A0A0A] via-transparent to-transparent" />
 
-                {/* Duration badge on image */}
-                {duration && (
-                  <div className="absolute right-3 bottom-3 flex items-center gap-1 rounded-lg bg-black/80 px-2 py-1 text-xs font-medium text-white backdrop-blur-sm">
-                    <Clock className="h-3 w-3" />
-                    {formatDuration(duration)}
-                  </div>
-                )}
-              </div>
-            )
-          : (
-              <div className="relative aspect-[16/9] w-full bg-gradient-to-br from-white/5 to-white/10">
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <div className="text-6xl font-bold text-white/20">
-                    {title.charAt(0).toUpperCase()}
-                  </div>
-                </div>
-
-                {/* Duration badge */}
-                {duration && (
-                  <div className="absolute right-3 bottom-3 flex items-center gap-1 rounded-lg bg-black/80 px-2 py-1 text-xs font-medium text-white backdrop-blur-sm">
-                    <Clock className="h-3 w-3" />
-                    {formatDuration(duration)}
-                  </div>
-                )}
+            {/* Duration badge on image */}
+            {duration && (
+              <div className="absolute right-3 bottom-3 flex items-center gap-1 rounded-lg bg-black/80 px-2 py-1 text-xs font-medium text-white backdrop-blur-sm">
+                <Clock className="h-3 w-3" />
+                {formatDuration(duration)}
               </div>
             )}
+          </div>
+        ) : (
+          <div className="relative aspect-[16/9] w-full bg-gradient-to-br from-white/5 to-white/10">
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="text-6xl font-bold text-white/20">
+                {title.charAt(0).toUpperCase()}
+              </div>
+            </div>
+
+            {/* Duration badge */}
+            {duration && (
+              <div className="absolute right-3 bottom-3 flex items-center gap-1 rounded-lg bg-black/80 px-2 py-1 text-xs font-medium text-white backdrop-blur-sm">
+                <Clock className="h-3 w-3" />
+                {formatDuration(duration)}
+              </div>
+            )}
+          </div>
+        )}
         {/* Content Section */}
         <div className="p-6">
           {/* Category Tag */}

--- a/src/components/content-grid-discover.tsx
+++ b/src/components/content-grid-discover.tsx
@@ -23,6 +23,9 @@ type CategoryGroup = {
 type ContentGridDiscoverProps = {
   categories: CategoryGroup[];
   locale: string;
+  surface?: "home" | "dashboard";
+  userId?: string;
+  experimentVariant?: string;
 };
 
 // Map category names to icons
@@ -50,6 +53,9 @@ const getCategoryIcon = (categoryName: string) => {
 export function ContentGridDiscover({
   categories,
   locale,
+  surface = "home",
+  userId,
+  experimentVariant,
 }: ContentGridDiscoverProps) {
   // Get all items for "For You" (all content)
   const allItems = categories.flatMap((cat) => cat.items);
@@ -281,6 +287,9 @@ export function ContentGridDiscover({
                   duration={item.duration}
                   index={index}
                   locale={locale}
+                  surface={surface}
+                  userId={userId}
+                  experimentVariant={experimentVariant}
                 />
               </div>
             );

--- a/src/components/discover-grid.tsx
+++ b/src/components/discover-grid.tsx
@@ -30,6 +30,9 @@ type CategoryGroup = {
 type DiscoverGridProps = {
   categories: CategoryGroup[];
   locale: string;
+  surface?: "home" | "dashboard";
+  userId?: string;
+  experimentVariant?: string;
 };
 
 // Map category names to icons
@@ -54,7 +57,13 @@ const getCategoryIcon = (categoryName: string) => {
   return Star;
 };
 
-export function DiscoverGrid({ categories, locale }: DiscoverGridProps) {
+export function DiscoverGrid({
+  categories,
+  locale,
+  surface = "dashboard",
+  userId,
+  experimentVariant,
+}: DiscoverGridProps) {
   // Get all items for "For You" (all content)
   const allItems = categories.flatMap((cat) => cat.items);
 
@@ -286,6 +295,9 @@ export function DiscoverGrid({ categories, locale }: DiscoverGridProps) {
                   duration={item.duration}
                   index={index}
                   locale={locale}
+                  surface={surface}
+                  userId={userId}
+                  experimentVariant={experimentVariant}
                 />
               </div>
             );

--- a/src/hooks/useContentAnalytics.ts
+++ b/src/hooks/useContentAnalytics.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { usePostHog } from "posthog-js/react";
+import { useCallback } from "react";
+
+type Surface = "home" | "dashboard";
+
+type ContentEventProperties = {
+  user_id?: string;
+  content_name: string;
+  content_category: string;
+  content_id: string;
+  surface: Surface;
+  experiment_variant?: string;
+};
+
+export const useContentAnalytics = () => {
+  const posthog = usePostHog();
+
+  const trackContentViewed = useCallback(
+    (properties: ContentEventProperties) => {
+      if (!posthog) {
+        return;
+      }
+
+      posthog.capture("content_viewed", {
+        user_id: properties.user_id || posthog.get_distinct_id(),
+        content_name: properties.content_name,
+        content_category: properties.content_category,
+        content_id: properties.content_id,
+        surface: properties.surface,
+        experiment_variant: properties.experiment_variant,
+      });
+    },
+    [posthog],
+  );
+
+  const trackContentPlayStarted = useCallback(
+    (properties: ContentEventProperties) => {
+      if (!posthog) {
+        return;
+      }
+
+      posthog.capture("content_play_started", {
+        user_id: properties.user_id || posthog.get_distinct_id(),
+        content_name: properties.content_name,
+        content_category: properties.content_category,
+        content_id: properties.content_id,
+        surface: properties.surface,
+        experiment_variant: properties.experiment_variant,
+      });
+    },
+    [posthog],
+  );
+
+  const trackContentPlayCompleted = useCallback(
+    (properties: ContentEventProperties) => {
+      if (!posthog) {
+        return;
+      }
+
+      posthog.capture("content_play_completed", {
+        user_id: properties.user_id || posthog.get_distinct_id(),
+        content_name: properties.content_name,
+        content_category: properties.content_category,
+        content_id: properties.content_id,
+        surface: properties.surface,
+        experiment_variant: properties.experiment_variant,
+      });
+    },
+    [posthog],
+  );
+
+  return {
+    trackContentViewed,
+    trackContentPlayStarted,
+    trackContentPlayCompleted,
+  };
+};


### PR DESCRIPTION
- Home page (logged out): defaults to "Top" feed
- Dashboard (logged in): defaults to "For You" feed showing all content
- Renamed "All" tab to "For You" in dashboard for clarity
- Fixed tab state initialization to match available tab IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added analytics tracking for content interactions, including views, plays, and completions.

* **Improvements**
  * Enhanced component rendering with context-aware display modes for different surfaces.
  * Improved configuration validation with better error handling for missing setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->