### PR TITLE
feat: add PWA manifest with dark theme configuration

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,41 @@
+{
+  "name": "Speasy - Turn Articles Into Podcasts",
+  "short_name": "Speasy",
+  "description": "Transform newsletters and saved articles into personal podcast-style audio you can listen to anytime.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a090c",
+  "theme_color": "#0a090c",
+  "orientation": "portrait-primary",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    }
+  ],
+  "categories": ["productivity", "news", "entertainment"],
+  "lang": "en"
+}


### PR DESCRIPTION
Add manifest.json with dark theme colors to fix white flash on iOS PWA splash screen and status bar.

- Set theme_color and background_color to #0a090c
- Configure PWA metadata (name, icons, display mode)
- Supports both Android and iOS PWA installation
- Complements existing PWA meta tags in root layout

Fixes white flash issue during PWA app launch on mobile devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progressive Web App support enabled. Users can now install the application directly on their devices with custom icons and branding optimized for multiple screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->