### PR TITLE
feat: add manifesto marketing page

### DIFF
--- a/src/app/[locale]/(marketing)/about/page.tsx
+++ b/src/app/[locale]/(marketing)/about/page.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
+import { motion } from 'framer-motion';
 import {
   ArrowRight,
   BookOpen,
@@ -11,11 +11,11 @@ import {
   Target,
   Users,
   Zap,
-} from "lucide-react";
-import Link from "next/link";
-import { Footer } from "@/components/footer";
-import { ScrollProgress } from "@/components/scroll-progress";
-import { Button } from "@/components/ui/button";
+} from 'lucide-react';
+import Link from 'next/link';
+import { Footer } from '@/components/footer';
+import { ScrollProgress } from '@/components/scroll-progress';
+import { Button } from '@/components/ui/button';
 
 export default function AboutPage() {
   return (
@@ -33,8 +33,8 @@ export default function AboutPage() {
               className="h-full w-full"
               style={{
                 backgroundImage:
-                  "linear-gradient(to right, white 1px, transparent 1px), linear-gradient(to bottom, white 1px, transparent 1px)",
-                backgroundSize: "80px 80px",
+                  'linear-gradient(to right, white 1px, transparent 1px), linear-gradient(to bottom, white 1px, transparent 1px)',
+                backgroundSize: '80px 80px',
               }}
             />
           </div>
@@ -50,7 +50,8 @@ export default function AboutPage() {
               }}
               className="text-4xl leading-[1.1] font-bold tracking-tight text-white md:text-5xl lg:text-6xl"
             >
-              Reclaim your time.{" "}
+              Reclaim your time.
+              {' '}
               <span className="bg-gradient-to-r from-white via-white to-gray-400 bg-clip-text text-transparent">
                 Rewrite your story.
               </span>
@@ -83,7 +84,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-4"
             >
@@ -105,7 +106,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-8"
             >
@@ -128,7 +129,8 @@ export default function AboutPage() {
 
                 <p>
                   Reading needs stillness, focus, and a screen. Most days do not
-                  offer that.{" "}
+                  offer that.
+                  {' '}
                   <span className="font-medium text-white">
                     Listening does.
                   </span>
@@ -163,7 +165,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-8"
             >
@@ -180,16 +182,16 @@ export default function AboutPage() {
                 {[
                   {
                     icon: Target,
-                    text: "Fresh content from the topics you choose",
+                    text: 'Fresh content from the topics you choose',
                   },
-                  { icon: Zap, text: "Clean, studio-quality voices" },
+                  { icon: Zap, text: 'Clean, studio-quality voices' },
                   {
                     icon: BookOpen,
-                    text: "Delivered through a simple web player and podcast feeds",
+                    text: 'Delivered through a simple web player and podcast feeds',
                   },
                   {
                     icon: Sparkles,
-                    text: "Works with Apple Podcasts, Overcast, and more",
+                    text: 'Works with Apple Podcasts, Overcast, and more',
                   },
                 ].map((item, index) => (
                   <motion.div
@@ -225,7 +227,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-8"
             >
@@ -265,7 +267,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-8"
             >
@@ -280,18 +282,18 @@ export default function AboutPage() {
 
               <div className="grid gap-4 sm:grid-cols-2">
                 {[
-                  { icon: Users, text: "Busy professionals aged 25–45" },
+                  { icon: Users, text: 'Busy professionals aged 25–45' },
                   {
                     icon: Brain,
-                    text: "Founders, makers, and knowledge workers",
+                    text: 'Founders, makers, and knowledge workers',
                   },
                   {
                     icon: BookOpen,
-                    text: "People who already listen to podcasts",
+                    text: 'People who already listen to podcasts',
                   },
                   {
                     icon: Clock,
-                    text: "Anyone with a growing backlog of saved reads",
+                    text: 'Anyone with a growing backlog of saved reads',
                   },
                 ].map((item, index) => (
                   <motion.div
@@ -327,7 +329,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-8"
             >
@@ -338,21 +340,21 @@ export default function AboutPage() {
               <div className="space-y-4">
                 {[
                   {
-                    q: "Does it save time?",
-                    a: "Yes. You use time that already exists.",
+                    q: 'Does it save time?',
+                    a: 'Yes. You use time that already exists.',
                   },
                   {
-                    q: "Is the audio good?",
-                    a: "Yes. Clear, natural voices designed for long listening.",
+                    q: 'Is the audio good?',
+                    a: 'Yes. Clear, natural voices designed for long listening.',
                   },
-                  { q: "Is it simple?", a: "Yes. Choose topics. Press play." },
+                  { q: 'Is it simple?', a: 'Yes. Choose topics. Press play.' },
                   {
-                    q: "Is my data safe?",
-                    a: "Yes. Your feed is private and yours alone.",
+                    q: 'Is my data safe?',
+                    a: 'Yes. Your feed is private and yours alone.',
                   },
                   {
-                    q: "Will it stay useful?",
-                    a: "Yes. You control what goes in.",
+                    q: 'Will it stay useful?',
+                    a: 'Yes. You control what goes in.',
                   },
                 ].map((item, index) => (
                   <motion.div
@@ -384,7 +386,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-6"
             >
@@ -394,7 +396,8 @@ export default function AboutPage() {
 
               <div className="space-y-6 text-lg leading-relaxed text-gray-300">
                 <p>
-                  Speasy is made by{" "}
+                  Speasy is made by
+                  {' '}
                   <a
                     href="https://rsimms.com"
                     target="_blank"
@@ -418,7 +421,8 @@ export default function AboutPage() {
 
                 <p>
                   A quiet fix to a real problem.
-                  <br />A tool that respects time, focus, and everyday life.
+                  <br />
+                  A tool that respects time, focus, and everyday life.
                 </p>
 
                 <p>
@@ -453,7 +457,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-8"
             >
@@ -465,23 +469,23 @@ export default function AboutPage() {
                 {[
                   {
                     icon: Zap,
-                    title: "Simplicity",
-                    description: "The best tools stay out of the way.",
+                    title: 'Simplicity',
+                    description: 'The best tools stay out of the way.',
                   },
                   {
                     icon: Heart,
-                    title: "Respect",
-                    description: "Your time and focus matter.",
+                    title: 'Respect',
+                    description: 'Your time and focus matter.',
                   },
                   {
                     icon: Sparkles,
-                    title: "Care",
-                    description: "Quality over noise, always.",
+                    title: 'Care',
+                    description: 'Quality over noise, always.',
                   },
                   {
                     icon: Target,
-                    title: "Growth",
-                    description: "Learning should support life, not crowd it.",
+                    title: 'Growth',
+                    description: 'Learning should support life, not crowd it.',
                   },
                 ].map((value, index) => (
                   <motion.div
@@ -516,7 +520,7 @@ export default function AboutPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-6"
             >

--- a/src/app/[locale]/(marketing)/manifesto/page.tsx
+++ b/src/app/[locale]/(marketing)/manifesto/page.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
+import { motion } from 'framer-motion';
 import {
   ArrowRight,
   Clock,
@@ -12,88 +12,88 @@ import {
   Sparkles,
   Target,
   Zap,
-} from "lucide-react";
-import Link from "next/link";
-import { Footer } from "@/components/footer";
-import { ScrollProgress } from "@/components/scroll-progress";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+} from 'lucide-react';
+import Link from 'next/link';
+import { Footer } from '@/components/footer';
+import { ScrollProgress } from '@/components/scroll-progress';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 
 const manifestoItems = [
   {
-    title: "Time matters",
+    title: 'Time matters',
     description:
-      "Time is the one thing you never get back. Speasy exists to respect it.",
+      'Time is the one thing you never get back. Speasy exists to respect it.',
     icon: Clock,
-    color: "from-violet-500/20 to-purple-500/20",
+    color: 'from-violet-500/20 to-purple-500/20',
   },
   {
-    title: "Knowledge should fit your life",
+    title: 'Knowledge should fit your life',
     description:
-      "Learning should work around your day, not fight it. If reading does not fit, listening should.",
+      'Learning should work around your day, not fight it. If reading does not fit, listening should.',
     icon: Compass,
-    color: "from-blue-500/20 to-cyan-500/20",
+    color: 'from-blue-500/20 to-cyan-500/20',
   },
   {
-    title: "No guilt, no backlog",
+    title: 'No guilt, no backlog',
     description:
-      "Saved articles are not a failure. They are good intent stuck in the wrong format.",
+      'Saved articles are not a failure. They are good intent stuck in the wrong format.',
     icon: Heart,
-    color: "from-pink-500/20 to-rose-500/20",
+    color: 'from-pink-500/20 to-rose-500/20',
   },
   {
-    title: "Listen when it suits you",
-    description: "Walking, commuting, cooking, resting. Speasy moves with you.",
+    title: 'Listen when it suits you',
+    description: 'Walking, commuting, cooking, resting. Speasy moves with you.',
     icon: Ear,
-    color: "from-emerald-500/20 to-teal-500/20",
+    color: 'from-emerald-500/20 to-teal-500/20',
   },
   {
-    title: "Simple over clever",
+    title: 'Simple over clever',
     description:
-      "Clear audio. Few steps. No clutter. If it takes effort, it is wrong.",
+      'Clear audio. Few steps. No clutter. If it takes effort, it is wrong.',
     icon: Zap,
-    color: "from-amber-500/20 to-orange-500/20",
+    color: 'from-amber-500/20 to-orange-500/20',
   },
   {
-    title: "Quality earns trust",
+    title: 'Quality earns trust',
     description:
-      "Audio should sound calm and human. Sources should be clear. Nothing hidden.",
+      'Audio should sound calm and human. Sources should be clear. Nothing hidden.',
     icon: Shield,
-    color: "from-indigo-500/20 to-violet-500/20",
+    color: 'from-indigo-500/20 to-violet-500/20',
   },
   {
-    title: "You stay in control",
+    title: 'You stay in control',
     description:
-      "Your interests. Your pace. Your feed. Speasy does not decide for you.",
+      'Your interests. Your pace. Your feed. Speasy does not decide for you.',
     icon: Target,
-    color: "from-rose-500/20 to-pink-500/20",
+    color: 'from-rose-500/20 to-pink-500/20',
   },
   {
-    title: "Learning without pressure",
+    title: 'Learning without pressure',
     description:
-      "No chasing streaks. No noise. Just steady progress, your way.",
+      'No chasing streaks. No noise. Just steady progress, your way.',
     icon: Lightbulb,
-    color: "from-cyan-500/20 to-blue-500/20",
+    color: 'from-cyan-500/20 to-blue-500/20',
   },
   {
-    title: "Reclaim your time",
+    title: 'Reclaim your time',
     description:
-      "Not to do more work, but to think, grow, and live a bit better.",
+      'Not to do more work, but to think, grow, and live a bit better.',
     icon: Sparkles,
-    color: "from-purple-500/20 to-violet-500/20",
+    color: 'from-purple-500/20 to-violet-500/20',
   },
 ];
 
 function PlaceholderImage({
   className,
-  variant = "hero",
+  variant = 'hero',
 }: {
   className?: string;
-  variant?: "hero" | "section";
+  variant?: 'hero' | 'section';
 }) {
   const gradients = {
-    hero: "from-purple-600/30 via-blue-600/20 to-cyan-600/30",
-    section: "from-violet-500/20 via-purple-500/10 to-blue-500/20",
+    hero: 'from-purple-600/30 via-blue-600/20 to-cyan-600/30',
+    section: 'from-violet-500/20 via-purple-500/10 to-blue-500/20',
   };
 
   return (
@@ -105,8 +105,8 @@ function PlaceholderImage({
           className="h-full w-full"
           style={{
             backgroundImage:
-              "radial-gradient(circle at 1px 1px, currentColor 1px, transparent 0)",
-            backgroundSize: "32px 32px",
+              'radial-gradient(circle at 1px 1px, currentColor 1px, transparent 0)',
+            backgroundSize: '32px 32px',
           }}
         />
       </div>
@@ -133,8 +133,8 @@ export default function ManifestoPage() {
               className="h-full w-full"
               style={{
                 backgroundImage:
-                  "linear-gradient(to right, white 1px, transparent 1px), linear-gradient(to bottom, white 1px, transparent 1px)",
-                backgroundSize: "80px 80px",
+                  'linear-gradient(to right, white 1px, transparent 1px), linear-gradient(to bottom, white 1px, transparent 1px)',
+                backgroundSize: '80px 80px',
               }}
             />
           </div>
@@ -150,7 +150,8 @@ export default function ManifestoPage() {
               }}
               className="text-4xl leading-[1.1] font-bold tracking-tight text-white md:text-5xl lg:text-6xl"
             >
-              What we{" "}
+              What we
+              {' '}
               <span className="bg-gradient-to-r from-white via-white to-gray-400 bg-clip-text text-transparent">
                 believe in
               </span>
@@ -183,7 +184,7 @@ export default function ManifestoPage() {
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="grid gap-12 md:grid-cols-2 md:items-center"
             >
@@ -221,7 +222,7 @@ export default function ManifestoPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-12"
             >
@@ -231,7 +232,7 @@ export default function ManifestoPage() {
                     key={item.title}
                     initial={{ opacity: 0, y: 16 }}
                     whileInView={{ opacity: 1, y: 0 }}
-                    viewport={{ once: true, margin: "-50px" }}
+                    viewport={{ once: true, margin: '-50px' }}
                     transition={{
                       duration: 0.5,
                       delay: index * 0.08,
@@ -277,7 +278,7 @@ export default function ManifestoPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="grid gap-12 md:grid-cols-2 md:items-center"
             >
@@ -313,7 +314,7 @@ export default function ManifestoPage() {
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="grid gap-12 md:grid-cols-2 md:items-center"
             >
@@ -352,7 +353,7 @@ export default function ManifestoPage() {
             <motion.div
               initial={{ opacity: 0 }}
               whileInView={{ opacity: 1 }}
-              viewport={{ once: true, margin: "-50px" }}
+              viewport={{ once: true, margin: '-50px' }}
               transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
               className="space-y-6"
             >

--- a/src/components/dashboard-sidebar.tsx
+++ b/src/components/dashboard-sidebar.tsx
@@ -1,12 +1,12 @@
-"use client";
+'use client';
 
-import type { LucideIcon } from "lucide-react";
-import { FileText, Heart, Home, Menu, Newspaper, Radio, X } from "lucide-react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useEffect, useId, useState } from "react";
-import { usePlaybackOptional } from "@/components/audio/playback-provider";
-import { cn } from "@/libs/utils";
+import type { LucideIcon } from 'lucide-react';
+import { FileText, Heart, Home, Menu, Newspaper, Radio, X } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useId, useState } from 'react';
+import { usePlaybackOptional } from '@/components/audio/playback-provider';
+import { cn } from '@/libs/utils';
 
 type SidebarProps = {
   currentPath?: string;
@@ -27,45 +27,45 @@ type SidebarNavProps = {
 };
 
 function normalizePathname(pathname: string) {
-  const trimmed = pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
-  const segments = trimmed.split("/").filter(Boolean);
+  const trimmed = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+  const segments = trimmed.split('/').filter(Boolean);
 
   if (segments.length === 0) {
-    return "/";
+    return '/';
   }
 
   const [first, ...rest] = segments;
-  const looksLikeLocale = /^[a-z]{2}(?:-[a-z]{2})?$/i.test(first ?? "");
+  const looksLikeLocale = /^[a-z]{2}(?:-[a-z]{2})?$/i.test(first ?? '');
   if (!looksLikeLocale) {
-    return `/${segments.join("/")}`;
+    return `/${segments.join('/')}`;
   }
 
   if (rest.length === 0) {
-    return "/";
+    return '/';
   }
 
-  return `/${rest.join("/")}`;
+  return `/${rest.join('/')}`;
 }
 
 function getNavItemActive(pathname: string, navItemId: string) {
   const normalizedPathname = normalizePathname(pathname);
 
-  if (navItemId === "home") {
-    return normalizedPathname === "/" || normalizedPathname === "/dashboard";
+  if (navItemId === 'home') {
+    return normalizedPathname === '/' || normalizedPathname === '/dashboard';
   }
 
-  if (navItemId === "digest") {
+  if (navItemId === 'digest') {
     return (
-      normalizedPathname === "/blog" || normalizedPathname.startsWith("/blog/")
+      normalizedPathname === '/blog' || normalizedPathname.startsWith('/blog/')
     );
   }
 
-  if (navItemId === "about") {
-    return normalizedPathname === "/about";
+  if (navItemId === 'about') {
+    return normalizedPathname === '/about';
   }
 
-  if (navItemId === "manifesto") {
-    return normalizedPathname === "/manifesto";
+  if (navItemId === 'manifesto') {
+    return normalizedPathname === '/manifesto';
   }
 
   return false;
@@ -84,11 +84,11 @@ function SidebarNav({ navItems, currentPath, onNavigate }: SidebarNavProps) {
             href={item.href}
             onClick={onNavigate}
             className={cn(
-              "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all",
-              "hover:bg-white/5 active:scale-95",
+              'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all',
+              'hover:bg-white/5 active:scale-95',
               isActive
-                ? "bg-white/10 text-white"
-                : "text-white/60 hover:text-white",
+                ? 'bg-white/10 text-white'
+                : 'text-white/60 hover:text-white',
             )}
           >
             <Icon className="h-5 w-5 shrink-0" />
@@ -112,19 +112,19 @@ function PlayerToggleCompact() {
       type="button"
       onClick={playback.togglePlayerEnabled}
       className={cn(
-        "inline-flex h-10 w-10 items-center justify-center rounded-lg text-white/80 transition-colors hover:bg-white/5 hover:text-white",
-        playback.playerEnabled &&
-          "bg-gradient-to-r from-blue-500/20 to-purple-500/20",
+        'inline-flex h-10 w-10 items-center justify-center rounded-lg text-white/80 transition-colors hover:bg-white/5 hover:text-white',
+        playback.playerEnabled
+        && 'bg-gradient-to-r from-blue-500/20 to-purple-500/20',
       )}
       aria-label={
         playback.playerEnabled
-          ? "Turn off radio player"
-          : "Turn on radio player"
+          ? 'Turn off radio player'
+          : 'Turn on radio player'
       }
       aria-pressed={playback.playerEnabled}
     >
       <Radio
-        className={cn("h-5 w-5", playback.playerEnabled && "text-blue-400")}
+        className={cn('h-5 w-5', playback.playerEnabled && 'text-blue-400')}
       />
     </button>
   );
@@ -142,31 +142,31 @@ function PlayerToggle({ className }: { className?: string }) {
       type="button"
       onClick={playback.togglePlayerEnabled}
       className={cn(
-        "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all",
-        "hover:bg-white/5 active:scale-95",
+        'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all',
+        'hover:bg-white/5 active:scale-95',
         playback.playerEnabled
-          ? "bg-gradient-to-r from-blue-500/20 to-purple-500/20 text-white"
-          : "text-white/60 hover:text-white",
+          ? 'bg-gradient-to-r from-blue-500/20 to-purple-500/20 text-white'
+          : 'text-white/60 hover:text-white',
         className,
       )}
       aria-label={
         playback.playerEnabled
-          ? "Turn off radio player"
-          : "Turn on radio player"
+          ? 'Turn off radio player'
+          : 'Turn on radio player'
       }
       aria-pressed={playback.playerEnabled}
     >
       <Radio
         className={cn(
-          "h-5 w-5 shrink-0",
-          playback.playerEnabled && "text-blue-400",
+          'h-5 w-5 shrink-0',
+          playback.playerEnabled && 'text-blue-400',
         )}
       />
       <span>Radio</span>
       <span
         className={cn(
-          "ml-auto h-2 w-2 rounded-full transition-colors",
-          playback.playerEnabled ? "bg-green-500" : "bg-white/20",
+          'ml-auto h-2 w-2 rounded-full transition-colors',
+          playback.playerEnabled ? 'bg-green-500' : 'bg-white/20',
         )}
         aria-hidden="true"
       />
@@ -178,7 +178,7 @@ export function DashboardSidebar({ currentPath }: SidebarProps) {
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const mobileDialogTitleId = useId();
   const pathname = usePathname();
-  const resolvedPathname = currentPath ?? pathname ?? "/dashboard";
+  const resolvedPathname = currentPath ?? pathname ?? '/dashboard';
 
   useEffect(() => {
     if (!isMobileOpen) {
@@ -186,50 +186,50 @@ export function DashboardSidebar({ currentPath }: SidebarProps) {
     }
 
     const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
+    document.body.style.overflow = 'hidden';
 
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key === 'Escape') {
         setIsMobileOpen(false);
       }
     };
 
-    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener('keydown', onKeyDown);
 
     return () => {
       document.body.style.overflow = previousOverflow;
-      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener('keydown', onKeyDown);
     };
   }, [isMobileOpen]);
 
   const navItems: NavItem[] = [
     {
-      id: "home",
-      label: "Home",
+      id: 'home',
+      label: 'Home',
       icon: Home,
-      href: "/",
-      active: getNavItemActive(resolvedPathname, "home"),
+      href: '/',
+      active: getNavItemActive(resolvedPathname, 'home'),
     },
     {
-      id: "digest",
-      label: "Digest",
+      id: 'digest',
+      label: 'Digest',
       icon: Newspaper,
-      href: "/blog",
-      active: getNavItemActive(resolvedPathname, "digest"),
+      href: '/blog',
+      active: getNavItemActive(resolvedPathname, 'digest'),
     },
     {
-      id: "about",
-      label: "About",
+      id: 'about',
+      label: 'About',
       icon: FileText,
-      href: "/about",
-      active: getNavItemActive(resolvedPathname, "about"),
+      href: '/about',
+      active: getNavItemActive(resolvedPathname, 'about'),
     },
     {
-      id: "manifesto",
-      label: "Manifesto",
+      id: 'manifesto',
+      label: 'Manifesto',
       icon: Heart,
-      href: "/manifesto",
-      active: getNavItemActive(resolvedPathname, "manifesto"),
+      href: '/manifesto',
+      active: getNavItemActive(resolvedPathname, 'manifesto'),
     },
   ];
 
@@ -374,8 +374,8 @@ export function DashboardSidebar({ currentPath }: SidebarProps) {
 
       <div
         className={cn(
-          "fixed inset-0 z-50 md:hidden",
-          isMobileOpen ? "pointer-events-auto" : "pointer-events-none",
+          'fixed inset-0 z-50 md:hidden',
+          isMobileOpen ? 'pointer-events-auto' : 'pointer-events-none',
         )}
         aria-hidden={!isMobileOpen}
       >
@@ -384,8 +384,8 @@ export function DashboardSidebar({ currentPath }: SidebarProps) {
           aria-label="Close menu"
           onClick={closeMobile}
           className={cn(
-            "absolute inset-0 bg-black/60 transition-opacity",
-            isMobileOpen ? "opacity-100" : "opacity-0",
+            'absolute inset-0 bg-black/60 transition-opacity',
+            isMobileOpen ? 'opacity-100' : 'opacity-0',
           )}
         />
 
@@ -394,8 +394,8 @@ export function DashboardSidebar({ currentPath }: SidebarProps) {
           aria-modal="true"
           aria-labelledby={mobileDialogTitleId}
           className={cn(
-            "absolute inset-y-0 left-0 w-72 border-r border-white/10 bg-[#100e12] shadow-xl transition-transform",
-            isMobileOpen ? "translate-x-0" : "-translate-x-full",
+            'absolute inset-y-0 left-0 w-72 border-r border-white/10 bg-[#100e12] shadow-xl transition-transform',
+            isMobileOpen ? 'translate-x-0' : '-translate-x-full',
           )}
         >
           <div className="flex h-full flex-col">


### PR DESCRIPTION
- Create new manifesto page at /manifesto with core Speasy beliefs
- Add animated sections with Framer Motion for smooth transitions
- Include placeholder images with gradient patterns
- Display 9 manifesto principles in responsive card grid
- Add navigation link to sidebar with Heart icon
- Follow existing marketing page patterns and design system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a Manifesto page with animated hero, responsive manifesto grid, featured callout, control/closing sections, decorative visuals, and CTAs.
  * Added a Manifesto link to the main navigation and an "About the maker" section with a manifesto CTA on the About page.

* **Style**
  * Simplified About page layouts: reduced hero height, streamlined typography, removed card-heavy blocks in favor of compact icon+text rows and tighter spacing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->