### PR TITLE
fix(sidebar): ensure centered logo link is clickable with proper z-index

### DIFF
--- a/src/components/dashboard-sidebar.tsx
+++ b/src/components/dashboard-sidebar.tsx
@@ -364,7 +364,7 @@ export function DashboardSidebar({ currentPath }: SidebarProps) {
         >
           <Menu className="h-5 w-5" />
         </button>
-        <div className="absolute left-1/2 -translate-x-1/2">
+        <div className="absolute left-1/2 z-10 -translate-x-1/2">
           <Link href="/" aria-label="Home">
             {simplifiedLogo}
           </Link>


### PR DESCRIPTION
Add z-10 to the centered logo container in mobile header to ensure it's clickable and not obscured by adjacent flex items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile header visual layering to ensure proper display above other elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->