### PR TITLE
fix(ui): set dark background on html/body to prevent white flash in in-app browsers

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,8 +4,8 @@
   "description": "Transform newsletters and saved articles into personal podcast-style audio you can listen to anytime.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#0a090c",
-  "theme_color": "#0a090c",
+  "background_color": "#100e12",
+  "theme_color": "#100e12",
   "orientation": "portrait-primary",
   "icons": [
     {

--- a/public/offline.html
+++ b/public/offline.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="theme-color" content="#0a090c">
+  <meta name="theme-color" content="#100e12">
   <title>Offline - Speasy</title>
   <link rel="icon" href="/favicon.ico">
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -66,7 +66,7 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: '#0a090c',
+  themeColor: '#100e12',
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
@@ -117,6 +117,7 @@ export default async function RootLayout(props: {
     <html
       lang={locale}
       className={`${GeistSans.variable} ${GeistMono.variable} ${GeistSans.className}`}
+      style={{ backgroundColor: '#100e12' }}
     >
       <body className="font-sans antialiased">
         <NextIntlClientProvider>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -8,7 +8,7 @@ export default function manifest(): MetadataRoute.Manifest {
     start_url: '/',
     display: 'standalone',
     background_color: '#100e12',
-    theme_color: '#0a090c',
+    theme_color: '#100e12',
     orientation: 'portrait-primary',
     icons: [
       {

--- a/src/app/offline/layout.tsx
+++ b/src/app/offline/layout.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: '#0a090c',
+  themeColor: '#100e12',
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
@@ -30,6 +30,7 @@ export default function OfflineLayout({
     <html
       lang="en"
       className={`${GeistSans.variable} ${GeistMono.variable} ${GeistSans.className}`}
+      style={{ backgroundColor: '#100e12' }}
     >
       <body className="font-sans antialiased">
         {children}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,13 @@
 
 @import 'tailwindcss';
 
+@layer base {
+  html,
+  body {
+    background-color: #100e12;
+  }
+}
+
 /* Content body styles for rendered HTML content */
 @layer components {
   .content-body {


### PR DESCRIPTION
In-app browsers (e.g., Instagram, Facebook, LinkedIn webviews) show a
white overscroll background because the root global.css had no background
color set on html/body. The dark background was only defined in the
marketing-specific globals.css which isn't imported at the root level.

- Add background-color: #100e12 to html and body in root global.css
- Add inline style on <html> for immediate paint before CSS loads
- Unify theme-color from #0a090c to #100e12 across all viewport meta
  tags, PWA manifests, and offline page

https://claude.ai/code/session_011WtTu7RXt5943ZeVMheum8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated primary theme color from #0a090c to #100e12 throughout the application, including browser UI theming, web app manifest, and global styling for consistent visual appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->