### PR TITLE
fix(audio): use useLayoutEffect for audio init to prevent autoplay race condition

### DIFF
--- a/src/components/audio/playback-provider.tsx
+++ b/src/components/audio/playback-provider.tsx
@@ -12,6 +12,7 @@ import {
   use,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -113,8 +114,11 @@ export function PlaybackProvider({ children }: PlaybackProviderProps) {
     return null;
   }, [queue, activeIndex]);
 
-  // Initialize audio element on mount (client-side only)
-  useEffect(() => {
+  // Create audio element in useLayoutEffect so it exists before child useEffects run.
+  // This prevents a race condition where autoplay effects in child components
+  // call playTrack() before the audio element is initialised (useEffect runs
+  // children-first, so a parent useEffect would be too late).
+  useLayoutEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }


### PR DESCRIPTION
The audio element was created in a parent useEffect, which runs AFTER
child useEffects (React fires effects depth-first). When visiting
/latest?autoplay=true, the autoplay effect in ContentGridDiscover
called playTrack() before PlaybackProvider's init effect created the
Audio element, causing playTrack to silently fail while openPlayer()
still opened the full player — resulting in "No track selected".

Switching to useLayoutEffect ensures the Audio element exists before
any child useEffects run (all useLayoutEffects complete before any
useEffects begin).

https://claude.ai/code/session_017tJaFJrSsT4hS1s1BpuHYz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an audio playback issue where autoplay could fail due to element initialization timing problems. Audio elements now initialize at the proper time during startup, ensuring reliable and consistent playback behavior. This prevents scenarios where audio might not start as expected or cause unexpected delays in playback functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->