### PR TITLE
fix(env): require Clerk webhook signing secret

### DIFF
--- a/src/libs/Env.ts
+++ b/src/libs/Env.ts
@@ -5,7 +5,7 @@ export const Env = createEnv({
   server: {
     ARCJET_KEY: z.string().startsWith('ajkey_').optional(),
     CLERK_SECRET_KEY: z.string().min(1),
-    CLERK_WEBHOOK_SIGNING_SECRET: z.string().min(1).optional(),
+    CLERK_WEBHOOK_SIGNING_SECRET: z.string().min(1),
     DATABASE_URL: z.string().min(1),
     SUPABASE_URL: z.string().url().optional(),
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),


### PR DESCRIPTION
### Motivation
- Ensure the app fails fast at startup when `CLERK_WEBHOOK_SIGNING_SECRET` is missing so Clerk webhook signature verification does not produce runtime 500s and cause silent Clerk→Supabase sync failures.

### Description
- Made `CLERK_WEBHOOK_SIGNING_SECRET` required by removing `.optional()` in `src/libs/Env.ts`, enforcing presence via the environment validator at startup.

### Testing
- Ran `npm run check:types` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3e88601748327b673666d2b474faf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Server configuration requirement updated: Webhook authentication secret is now mandatory and must be explicitly configured during deployment. Ensure this environment variable is properly set to prevent validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->