### PR TITLE
fix: prevent markdown fallback path traversal in blog slug handling

### DIFF
--- a/src/libs/blog.test.ts
+++ b/src/libs/blog.test.ts
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+let resolveSafeBlogPath: (slug: string) => string | null;
+
+beforeAll(async () => {
+  ({ resolveSafeBlogPath } = await import('./blog'));
+});
+
+describe('resolveSafeBlogPath', () => {
+  it('returns a path for a normal slug within the blog directory', () => {
+    const result = resolveSafeBlogPath('hello-world');
+
+    expect(result).toBe(path.resolve(process.cwd(), 'src', 'blog', 'hello-world.md'));
+  });
+
+  it('returns null for traversal attempts', () => {
+    expect(resolveSafeBlogPath('../../README')).toBeNull();
+    expect(resolveSafeBlogPath('../blog-post')).toBeNull();
+  });
+});

--- a/src/libs/blog.ts
+++ b/src/libs/blog.ts
@@ -17,9 +17,26 @@ function getSupabaseClient() {
 
 const BLOG_DIR = path.join(process.cwd(), 'src', 'blog');
 
+export function resolveSafeBlogPath(slug: string): string | null {
+  const blogDir = path.resolve(BLOG_DIR);
+  const fullPath = path.resolve(blogDir, `${slug}.md`);
+  const relativePath = path.relative(blogDir, fullPath);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    logger.warn('Path traversal attempt detected for markdown blog fallback', { slug, fullPath });
+    return null;
+  }
+
+  return fullPath;
+}
+
 async function parseMarkdownFile(slug: string): Promise<BlogPost | null> {
   try {
-    const fullPath = path.join(BLOG_DIR, `${slug}.md`);
+    const fullPath = resolveSafeBlogPath(slug);
+    if (!fullPath) {
+      return null;
+    }
+
     const raw = await fs.readFile(fullPath, 'utf8');
     const lines = raw.split('\n').filter(l => !l.startsWith('| '));
     const title = lines[0]?.replace(/^#\s*/, '').trim() || slug;


### PR DESCRIPTION
### Motivation
- The markdown fallback used to build file paths from unvalidated slugs, allowing path traversal (e.g. `../../README`) and reading arbitrary `.md` files outside `src/blog`.
- The change prevents accidental or malicious exposure of internal markdown files by ensuring only paths inside the blog directory are read.

### Description
- Add `resolveSafeBlogPath(slug: string): string | null` which canonicalizes the target with `path.resolve`, computes `path.relative` against the blog dir, logs and rejects any path that resolves outside `src/blog`, and returns the safe absolute path for valid slugs.
- Update `parseMarkdownFile` to call `resolveSafeBlogPath` and bail out (return `null`) if the slug is unsafe before attempting `fs.readFile`.
- Log blocked traversal attempts via `logger.warn` instead of reading or throwing, reducing information leakage.
- Add unit tests in `src/libs/blog.test.ts` that mock `server-only` and assert a valid slug resolves to the expected path and traversal slugs (e.g. `../../README`, `../blog-post`) return `null`.

### Testing
- Ran the unit test with environment fallbacks using `CLERK_SECRET_KEY=dummy DATABASE_URL=postgresql://localhost:5433/postgres NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=dummy NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run test -- src/libs/blog.test.ts`, and the test suite passed.
- Ran lint with `npm run lint -- src/libs/blog.ts src/libs/blog.test.ts`; lint completed successfully (existing repository warnings remain unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3e957b43483279b3c1f26fa22e884)