### PR TITLE
feat(ux): add skeleton loaders to all api-fetching pages

### DIFF
--- a/src/app/[locale]/(auth)/dashboard/loading.tsx
+++ b/src/app/[locale]/(auth)/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentGridLoadingSkeleton } from '@/components/content-grid-loading-skeleton';
+
+export default function DashboardLoading() {
+  return <ContentGridLoadingSkeleton />;
+}

--- a/src/app/[locale]/(marketing)/blog/loading.tsx
+++ b/src/app/[locale]/(marketing)/blog/loading.tsx
@@ -1,0 +1,21 @@
+import { ListItemSkeleton, Skeleton } from '@/components/ui/skeleton';
+
+export default function BlogLoading() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 md:px-6 lg:px-8">
+      <div className="space-y-8">
+        {/* Title skeleton — matches font-serif text-5xl h1 */}
+        <div className="mb-12">
+          <Skeleton variant="default" className="h-12 w-48 rounded-lg" />
+        </div>
+
+        {/* Blog post list */}
+        <div className="mx-0 max-w-3xl divide-y divide-white/10">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <ListItemSkeleton key={i} index={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(marketing)/category/[slug]/loading.tsx
+++ b/src/app/[locale]/(marketing)/category/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentGridLoadingSkeleton } from '@/components/content-grid-loading-skeleton';
+
+export default function CategoryLoading() {
+  return <ContentGridLoadingSkeleton />;
+}

--- a/src/app/[locale]/(marketing)/content/[id]/loading.tsx
+++ b/src/app/[locale]/(marketing)/content/[id]/loading.tsx
@@ -1,0 +1,37 @@
+import { AudioPlayerSkeleton, Skeleton } from '@/components/ui/skeleton';
+
+export default function ContentDetailLoading() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 pb-32 md:px-6 lg:px-8">
+      {/* Hero image */}
+      <Skeleton variant="card" className="mb-6 aspect-video w-full" />
+
+      {/* Category badge */}
+      <Skeleton variant="button" className="mb-4 h-6 w-24" />
+
+      {/* Title */}
+      <div className="mb-6 space-y-3">
+        <Skeleton variant="text" className="h-8 w-3/4" />
+        <Skeleton variant="text" className="h-8 w-1/2" />
+      </div>
+
+      {/* Body text */}
+      <div className="space-y-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton
+            key={i}
+            variant="text"
+            className={i % 3 === 2 ? 'w-4/6' : i % 3 === 1 ? 'w-5/6' : 'w-full'}
+          />
+        ))}
+      </div>
+
+      {/* Fixed bottom audio player */}
+      <div className="fixed inset-x-0 bottom-0 border-t border-white/10 bg-black/90 p-4">
+        <div className="mx-auto max-w-4xl">
+          <AudioPlayerSkeleton />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(marketing)/latest/loading.tsx
+++ b/src/app/[locale]/(marketing)/latest/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentGridLoadingSkeleton } from '@/components/content-grid-loading-skeleton';
+
+export default function LatestLoading() {
+  return <ContentGridLoadingSkeleton />;
+}

--- a/src/app/[locale]/(marketing)/loading.tsx
+++ b/src/app/[locale]/(marketing)/loading.tsx
@@ -1,0 +1,5 @@
+import { ContentGridLoadingSkeleton } from '@/components/content-grid-loading-skeleton';
+
+export default function HomeLoading() {
+  return <ContentGridLoadingSkeleton />;
+}

--- a/src/components/content-grid-loading-skeleton.tsx
+++ b/src/components/content-grid-loading-skeleton.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ContentCardSkeleton, Skeleton } from '@/components/ui/skeleton';
+
+const TAB_WIDTHS = ['w-14', 'w-16', 'w-20', 'w-18'] as const;
+
+export function ContentGridLoadingSkeleton() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8 md:px-6 lg:px-8">
+      {/* Tab row */}
+      <div className="mb-8 flex gap-2">
+        {TAB_WIDTHS.map(width => (
+          <Skeleton key={width} variant="button" className={`h-9 ${width}`} />
+        ))}
+      </div>
+
+      {/* Card grid */}
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <ContentCardSkeleton key={i} index={i} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds Next.js loading.tsx files for home, latest, category, content
detail, blog, and dashboard routes. Each uses a Suspense boundary that
streams an animated skeleton to the browser immediately while the server
resolves its Supabase data fetch, eliminating blank-screen wait on slow
connections.

A shared ContentGridLoadingSkeleton component handles the tabs + 3-column
card grid pattern used by four routes. The content detail and blog pages
get purpose-built inline skeletons. All reuse the existing Skeleton,
ContentCardSkeleton, AudioPlayerSkeleton, and ListItemSkeleton primitives
from src/components/ui/skeleton.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading skeleton screens across dashboard, blog, content details, and home pages for improved visual feedback while content loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->