### PR TITLE
fix: vary script openings and closings for llm audio summaries

### DIFF
--- a/supabase/functions/process_llm_job/index.ts
+++ b/supabase/functions/process_llm_job/index.ts
@@ -16,6 +16,14 @@ const openai = new OpenAI({
 // ─── Batch Configuration ──────────────────────────────────────────────
 const BATCH_SIZE = 5;
 
+type SummaryPromptVariant = {
+  name: string;
+  openingRule: string;
+  closingRule: string;
+  openingExample: string;
+  closingExample: string;
+};
+
 // ─── Podcast Script System Prompt ─────────────────────────────────────
 const SUMMARY_SYSTEM_PROMPT = `You are a podcast scriptwriter creating engaging audio content for busy professionals. Your goal is to write scripts that sound natural when spoken aloud—like a knowledgeable friend explaining something interesting over coffee.
 
@@ -57,6 +65,7 @@ Insert inline cues using double-parentheses to guide vocal delivery. Use sparing
 HOOK (15-25 words):
 Start mid-thought or with an intriguing angle. Pull them in immediately.
 Never start with: "Today we're discussing...", "In this article...", "This piece explores...", or the article title.
+Do NOT use generic openings like: "Let's dive into...", "Today we're looking at...", "Welcome back...", or "Here's your summary..."
 Good openings: "Here's something that caught my attention—", "So, [interesting finding]...", "You know how [relatable thing]? Well...", "[Bold statement]. And the implications are fascinating."
 
 CONTEXT + SO-WHAT (30-40 words):
@@ -69,6 +78,7 @@ Use phrases like: "According to [Author]...", "[Author] points out that...", "As
 CLOSE (20-30 words):
 Land the plane with a forward-looking thought, implication, or "what to watch for."
 Never use: "In conclusion," "To summarise," "In summary," or end with a generic call-to-action.
+Do NOT use formulaic sign-offs like: "That's all for today," "Thanks for listening," or "See you next time."
 
 5 | Attribution Rules (Non-negotiable)
 - Use the exact author and source names provided—never invent or guess
@@ -94,6 +104,7 @@ Never use: "In conclusion," "To summarise," "In summary," or end with a generic 
 ✗ Robotic summaries that could be written by any AI
 ✗ Saying "the author" instead of using their actual name
 ✗ Generic filler phrases ("In today's fast-paced world...")
+✗ Generic podcast framing and sign-offs ("Let's dive in", "That's all for today")
 
 8 | Key Insights Requirements
 Extract exactly 3 distinct insights that stand alone and immediately inform. Each insight should be:
@@ -139,6 +150,93 @@ THINGS TO AVOID:
 // nova: Energetic, upbeat, dynamic
 // onyx: Deeper, more gravitas, authoritative
 const DEFAULT_VOICE = 'shimmer';
+
+const SUMMARY_PROMPT_VARIANTS: readonly SummaryPromptVariant[] = [
+  {
+    name: 'surprising-fact-forward',
+    openingRule: 'Open with the single most surprising fact or tension in the piece. Start on the insight itself, not setup language.',
+    closingRule: 'Close on the strongest implication for what happens next, without sounding like a scripted sign-off.',
+    openingExample: 'Two out of three teams are now shipping faster with fewer releases. That sounds backwards, until you see what changed.',
+    closingExample: "If this pattern holds, next quarter's winners will be the teams that design for adaptability, not certainty.",
+  },
+  {
+    name: 'question-led',
+    openingRule: 'Start with one sharp question that frames the article stakes, then answer it immediately with a concrete point.',
+    closingRule: 'End with a provocative but grounded question tied to the article evidence.',
+    openingExample: 'What if your best growth channel is also the one quietly hurting retention? That is exactly what this data points to.',
+    closingExample: 'So the real question is not whether this trend continues, but who adapts before it becomes the default.',
+  },
+  {
+    name: 'bold-claim',
+    openingRule: "Begin with a confident, evidence-backed claim from the article's core argument. Keep it conversational, not theatrical.",
+    closingRule: 'End with a crisp key takeaway sentence that can stand on its own.',
+    openingExample: 'The old playbook for product launches is officially stale, and this case study makes that hard to ignore.',
+    closingExample: 'The takeaway is simple: durable advantage now comes from faster learning loops, not louder launches.',
+  },
+  {
+    name: 'drop-in-context',
+    openingRule: 'Drop listeners straight into a concrete scene, number, or decision moment from the article before expanding.',
+    closingRule: 'Finish naturally on a forward-looking thought without any meta-summary language.',
+    openingExample: 'At 8:07 on a Monday standup, one metric changed and the entire roadmap conversation flipped.',
+    closingExample: 'That shift is subtle now, but it is exactly the kind of signal that usually defines the next cycle.',
+  },
+];
+
+function selectSummaryPromptVariant(jobId: string): SummaryPromptVariant {
+  const hash = Array.from(jobId).reduce((acc, char) => ((acc * 31) + char.charCodeAt(0)) >>> 0, 0);
+  return SUMMARY_PROMPT_VARIANTS[hash % SUMMARY_PROMPT_VARIANTS.length]!;
+}
+
+function buildSummaryUserPrompt(args: {
+  title: string;
+  url: string;
+  author: string;
+  sourceName: string;
+  contentExcerpt: string;
+  variant: SummaryPromptVariant;
+}): string {
+  const {
+    title,
+    url,
+    author,
+    sourceName,
+    contentExcerpt,
+    variant,
+  } = args;
+  const attributionTarget = author !== 'Unknown' ? author : (sourceName !== 'Unknown' ? sourceName : 'the source');
+
+  return `Create a podcast-style audio summary for this article. Write for the ear, not the eye - this will be spoken aloud by a TTS system.
+
+Article Title: ${title}
+Article URL: ${url}
+Author: ${author}
+Source: ${sourceName}
+
+STYLE VARIANT (${variant.name}):
+- Opening: ${variant.openingRule}
+- Closing: ${variant.closingRule}
+
+Few-shot style cues (do not copy verbatim; mirror the style only):
+- Opening style example: "${variant.openingExample}"
+- Closing style example: "${variant.closingExample}"
+
+Critical anti-repetition rules:
+- Never open with generic phrases like "Let's dive into...", "Today we're looking at...", "Welcome back...", or "Here's your summary..."
+- Never close with generic phrases like "That's all for today", "Thanks for listening", "In conclusion", or "See you next time"
+- Start with the strongest insight from the article itself
+- End on a concrete implication, key insight, or forward-looking thought
+
+Article Content:
+${contentExcerpt}
+
+IMPORTANT REMINDERS:
+- Use contractions naturally throughout (it's, you'll, here's, don't)
+- Start with a hook, NOT the article title or "This article discusses..."
+- Include attribution to ${attributionTarget} at least twice
+- Vary sentence length for natural rhythm
+- Write like you're explaining this to a smart friend
+- Keep it 150-180 words total`;
+}
 
 // ─── Logging Helper ───────────────────────────────────────────────────
 const log = {
@@ -328,11 +426,26 @@ function validateSummaryQuality(summary: string, author: string, sourceName: str
     /^today we('re| are)/i,
     /^the article/i,
     /^this piece/i,
+    /^let'?s dive into/i,
+    /^today we'?re looking at/i,
+    /^welcome back/i,
+    /^here'?s your summary/i,
   ];
 
   for (const pattern of forbiddenOpenings) {
     if (pattern.test(summary.trim())) {
       issues.push('Summary starts with a forbidden phrase');
+    }
+  }
+
+  const forbiddenClosings = [
+    /that'?s all for today[\.\!\,]?$/i,
+    /thanks for listening[\.\!\,]?$/i,
+    /see you next time[\.\!\,]?$/i,
+  ];
+  for (const pattern of forbiddenClosings) {
+    if (pattern.test(summary.trim())) {
+      issues.push('Summary ends with a generic sign-off');
     }
   }
 
@@ -436,6 +549,13 @@ async function processOneJob(job: { id: string; content_id: string; retry_count:
   let summary = '';
   let keyInsights: string[] = [];
   const chatStartTime = Date.now();
+  const promptVariant = selectSummaryPromptVariant(job.id);
+
+  log.debug('Selected summary prompt variant', {
+    jobId: job.id,
+    contentId: job.content_id,
+    variant: promptVariant.name,
+  });
 
   try {
     const { choices } = await retryWithBackoff(
@@ -449,23 +569,14 @@ async function processOneJob(job: { id: string; content_id: string; retry_count:
           },
           {
             role: 'user',
-            content: `Create a podcast-style audio summary for this article. Write for the ear, not the eye—this will be spoken aloud by a TTS system.
-
-Article Title: ${item.title}
-Article URL: ${item.url}
-Author: ${item.author || 'Unknown'}
-Source: ${sourceName || 'Unknown'}
-
-Article Content:
-${content.slice(0, 12000)}
-
-IMPORTANT REMINDERS:
-- Use contractions naturally throughout (it's, you'll, here's, don't)
-- Start with a hook, NOT the article title or "This article discusses..."
-- Include attribution to ${item.author || sourceName || 'the source'} at least twice
-- Vary sentence length for natural rhythm
-- Write like you're explaining this to a smart friend
-- Keep it 150-180 words total`,
+            content: buildSummaryUserPrompt({
+              title: item.title || 'Untitled',
+              url: item.url || 'Unknown',
+              author: item.author || 'Unknown',
+              sourceName: sourceName || 'Unknown',
+              contentExcerpt: content.slice(0, 12000),
+              variant: promptVariant,
+            }),
           },
         ],
       }),

--- a/supabase/functions/process_llm_job/index.ts
+++ b/supabase/functions/process_llm_job/index.ts
@@ -16,6 +16,9 @@ const openai = new OpenAI({
 // ─── Batch Configuration ──────────────────────────────────────────────
 const BATCH_SIZE = 5;
 
+// OpenAI TTS currently returns 128kbps mono MP3 output.
+const TTS_BITRATE_BPS = 128000;
+
 type SummaryPromptVariant = {
   name: string;
   openingRule: string;
@@ -276,11 +279,17 @@ async function retryWithBackoff<T>(
 }
 
 // ─── Job Status Helpers ───────────────────────────────────────────────
-async function markJobDone(jobId: string) {
-  const { error } = await sb.from('llm_jobs').update({
+async function markJobDone(jobId: string, processingTimeMs?: number) {
+  const updateData: Record<string, string | number> = {
     status: 'done',
     completed_at: new Date().toISOString(),
-  }).eq('id', jobId);
+  };
+
+  if (processingTimeMs !== undefined) {
+    updateData.processing_time_ms = processingTimeMs;
+  }
+
+  const { error } = await sb.from('llm_jobs').update(updateData).eq('id', jobId);
   if (error) {
     log.error(`Failed to mark job ${jobId} as done:`, error);
   }
@@ -759,6 +768,8 @@ Return only the query.`,
     return { success: false };
   }
 
+  const audioDurationSeconds = Math.round((audioBuf.byteLength * 8) / TTS_BITRATE_BPS);
+
   // Save summary, insights, image, and audio
   await sb
     .from('content_items')
@@ -775,9 +786,11 @@ Return only the query.`,
     file_url: urlData.publicUrl,
     format: 'mp3',
     type: 'summary',
+    duration: audioDurationSeconds,
   });
 
-  await markJobDone(job.id);
+  const processingTimeMs = Date.now() - jobStartTime;
+  await markJobDone(job.id, processingTimeMs);
 
   const totalDuration = Date.now() - jobStartTime;
   log.success(`Job completed successfully in ${totalDuration}ms`, {
@@ -785,6 +798,8 @@ Return only the query.`,
     contentId: job.content_id,
     title: item.title,
     totalDuration,
+    processingTimeMs,
+    audioDurationSeconds,
     hasImage: !!imageUrl,
     wordCount: summary.split(/\s+/).length,
   });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2,13 +2,24 @@
 
 ## Plan
 
-- [ ] Confirm current `process_llm_job` prompt path and baseline behavior
-- [ ] Add rotating opening/closing style variants to summary prompt instructions
-- [ ] Tighten guardrails against repetitive generic intros and sign-offs
-- [ ] Run lint and type checks for repository safety
-- [ ] Commit, push, and open/update PR
+- [x] Confirm current `process_llm_job` prompt path and baseline behavior
+- [x] Add rotating opening/closing style variants to summary prompt instructions
+- [x] Tighten guardrails against repetitive generic intros and sign-offs
+- [x] Run lint and type checks for repository safety
+- [x] Commit, push, and open/update PR
 - [ ] Deploy updated `process_llm_job` edge function to `speasy-signups`
 
 ## Review
 
-- Pending
+- Implemented RS-879 in `supabase/functions/process_llm_job/index.ts`:
+  - Added explicit anti-generic opening/closing prompt constraints.
+  - Added deterministic 4-variant prompt rotation via `selectSummaryPromptVariant(job.id)`.
+  - Added few-shot opening/closing style cues through `buildSummaryUserPrompt`.
+  - Extended summary validation warnings for repetitive opening/closing phrases.
+- Preserved existing production-only telemetry logic from deployed function:
+  - `TTS_BITRATE_BPS` and duration calculation for `audio_files.duration`.
+  - `markJobDone(jobId, processingTimeMs)` and processing-time persistence.
+- Validation:
+  - `pnpm run check:types` ✅
+  - `pnpm test` ✅ (after installing Playwright Chromium in this environment)
+  - `pnpm run lint` ✅ with pre-existing repo warnings only (no errors).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,14 @@
+# RS-879 - Vary audio script openings and closings
+
+## Plan
+
+- [ ] Confirm current `process_llm_job` prompt path and baseline behavior
+- [ ] Add rotating opening/closing style variants to summary prompt instructions
+- [ ] Tighten guardrails against repetitive generic intros and sign-offs
+- [ ] Run lint and type checks for repository safety
+- [ ] Commit, push, and open/update PR
+- [ ] Deploy updated `process_llm_job` edge function to `speasy-signups`
+
+## Review
+
+- Pending


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement RS-879 in `process_llm_job` with explicit anti-repetition guidance for script openings and closings
- add deterministic prompt variant rotation (4 opening/closing styles) keyed by job ID so scripts vary across jobs
- include few-shot opening/closing style cues in the user prompt while preserving JSON output + attribution constraints
- extend summary quality validation warnings to catch generic intro/sign-off patterns
- preserve current production telemetry behavior from deployed function (`audio_files.duration` calculation and `llm_jobs.processing_time_ms` update)
- track execution and verification in `tasks/todo.md`

## Related
- Linear: RS-879

## Validation
- `pnpm run check:types` ✅
- `pnpm test` ✅
- `pnpm run lint` ✅ (existing warnings only, no errors)

## Notes
- This environment does not have Supabase CLI available, so deployment from local shell was not performed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d17f2a6-40d5-4f58-9e09-94f870dd690c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d17f2a6-40d5-4f58-9e09-94f870dd690c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

