### PR TITLE
Update discover content cards for full-width mobile and footer actions

### DIFF
--- a/src/components/audio/full-player.tsx
+++ b/src/components/audio/full-player.tsx
@@ -12,6 +12,16 @@ import { MOTION } from '@/libs/motion-config';
 import { cn } from '@/libs/utils';
 import { usePlayback } from './playback-provider';
 
+const decodeHtmlEntities = (value: string): string => {
+  if (typeof window === 'undefined') {
+    return value;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = value;
+  return textarea.value;
+};
+
 /**
  * Full player sheet (~90vh) with queue display and extended controls
  * Supports swipe-down gesture to close
@@ -100,6 +110,9 @@ export function FullPlayer() {
 
   // Get upcoming tracks (next 5 in queue)
   const upcomingTracks = queue.slice(activeIndex + 1, activeIndex + 6);
+  const decodedTrackTitle = activeTrack
+    ? decodeHtmlEntities(activeTrack.title)
+    : null;
 
   const progress = durationSec ? (currentTimeSec / durationSec) * 100 : 0;
 
@@ -172,7 +185,7 @@ export function FullPlayer() {
             style={{ zIndex: 9999 }}
             role="dialog"
             aria-modal="true"
-            aria-label={`Now Playing: ${activeTrack?.title ?? 'No track selected'}`}
+            aria-label={`Now Playing: ${decodedTrackTitle ?? 'No track selected'}`}
           >
             {/* Drag handle */}
             <div
@@ -239,7 +252,7 @@ export function FullPlayer() {
                           {/* Track title and category */}
                           <div className="w-full max-w-md text-center">
                             <h2 className="mb-2 line-clamp-2 text-xl font-bold text-white sm:text-2xl">
-                              {activeTrack.title}
+                              {decodedTrackTitle}
                             </h2>
                             <p className="text-sm text-white/60">
                               {activeTrack.category}

--- a/src/components/audio/mini-player.tsx
+++ b/src/components/audio/mini-player.tsx
@@ -10,6 +10,16 @@ import { MOTION } from '@/libs/motion-config';
 import { cn } from '@/libs/utils';
 import { usePlayback } from './playback-provider';
 
+const decodeHtmlEntities = (value: string): string => {
+  if (typeof window === 'undefined') {
+    return value;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = value;
+  return textarea.value;
+};
+
 /**
  * Mini player bar that appears at the bottom when a track is active
  * Clicking anywhere opens the full player
@@ -126,6 +136,7 @@ export function MiniPlayer() {
     return null;
   }
 
+  const decodedTrackTitle = decodeHtmlEntities(activeTrack.title);
   const progress = durationSec ? (currentTimeSec / durationSec) * 100 : 0;
 
   // Desktop left offset based on sidebar state: 78px closed, 190px open
@@ -179,7 +190,7 @@ export function MiniPlayer() {
               ? (
                   <Image
                     src={activeTrack.imageUrl}
-                    alt={activeTrack.title}
+                    alt={decodedTrackTitle}
                     fill
                     className="object-cover"
                     sizes="48px"
@@ -187,7 +198,7 @@ export function MiniPlayer() {
                 )
               : (
                   <div className="flex h-full w-full items-center justify-center text-xl font-bold text-white/30">
-                    {activeTrack.title.charAt(0).toUpperCase()}
+                    {decodedTrackTitle.charAt(0).toUpperCase()}
                   </div>
                 )}
           </div>
@@ -195,7 +206,7 @@ export function MiniPlayer() {
           {/* Track info */}
           <div className="min-w-0 flex-1">
             <h3 className="truncate text-sm font-medium text-white">
-              {activeTrack.title}
+              {decodedTrackTitle}
             </h3>
             <div className="flex items-center gap-2 text-xs text-white/60">
               <span className="truncate">{activeTrack.category}</span>

--- a/src/components/content-detail-view.tsx
+++ b/src/components/content-detail-view.tsx
@@ -38,6 +38,16 @@ type ContentDetailViewProps = {
   experimentVariant?: string;
 };
 
+const decodeHtmlEntities = (value: string): string => {
+  if (typeof window === 'undefined') {
+    return value;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = value;
+  return textarea.value;
+};
+
 export function ContentDetailView({
   content,
   locale,
@@ -54,6 +64,9 @@ export function ContentDetailView({
   const hasTrackedPlayStart = useRef(false);
   const { trackContentPlayStarted, trackContentPlayCompleted }
     = useContentAnalytics();
+  const decodedSourceName = content.sourceName
+    ? decodeHtmlEntities(content.sourceName)
+    : null;
 
   // Format time from seconds to MM:SS
   const formatTime = (seconds: number): string => {
@@ -242,7 +255,7 @@ export function ContentDetailView({
                 <span>{formatTime(content.duration)}</span>
               </div>
             )}
-            {content.sourceName && (
+            {decodedSourceName && (
               <div className="flex items-center gap-2">
                 <span>•</span>
                 {content.sourceLink
@@ -251,15 +264,15 @@ export function ContentDetailView({
                         href={content.sourceLink}
                         target="_blank"
                         rel="noopener noreferrer"
-                        aria-label={`${content.sourceName} (opens in new tab)`}
+                        aria-label={`${decodedSourceName} (opens in new tab)`}
                         className="flex items-center gap-1 hover:text-white"
                       >
-                        {content.sourceName}
+                        {decodedSourceName}
                         <ExternalLink className="h-3 w-3" aria-hidden="true" />
                       </a>
                     )
                   : (
-                      <span>{content.sourceName}</span>
+                      <span>{decodedSourceName}</span>
                     )}
               </div>
             )}

--- a/src/components/content-grid-card.tsx
+++ b/src/components/content-grid-card.tsx
@@ -2,10 +2,10 @@
 
 import type { Track, VisibleQueueContext } from '@/types/audio';
 import { motion } from 'framer-motion';
-import { Clock, Pause, Play } from 'lucide-react';
+import { Clock, Pause, Play, Share2 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { usePlaybackOptional } from '@/components/audio/playback-provider';
 import { useContentAnalytics } from '@/hooks/useContentAnalytics';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
@@ -56,6 +56,7 @@ export function ContentGridCard({
   const { trackContentViewed, trackContentPlayStarted } = useContentAnalytics();
   const playback = usePlaybackOptional();
   const reducedMotion = useReducedMotion();
+  const [shareMessage, setShareMessage] = useState('');
 
   // Check if this track is currently playing
   const isCurrentTrack = playback?.activeTrack?.id === id;
@@ -150,6 +151,40 @@ export function ContentGridCard({
     });
   };
 
+  const handleShareClick = useCallback(
+    async (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const shareUrl = typeof window !== 'undefined'
+        ? `${window.location.origin}/${locale}/content/${id}`
+        : `/${locale}/content/${id}`;
+
+      try {
+        if (typeof navigator !== 'undefined' && navigator.share) {
+          await navigator.share({
+            title,
+            text: summary ?? title,
+            url: shareUrl,
+          });
+          setShareMessage('Shared successfully.');
+          return;
+        }
+
+        if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(shareUrl);
+          setShareMessage('Link copied to clipboard.');
+          return;
+        }
+
+        setShareMessage('Sharing is not supported on this device.');
+      } catch {
+        setShareMessage('Could not share right now.');
+      }
+    },
+    [id, locale, summary, title],
+  );
+
   const handleClick = () => {
     trackContentViewed({
       user_id: userId,
@@ -179,12 +214,12 @@ export function ContentGridCard({
               ease: MOTION.easing.default,
             }
       }
-      className="group relative overflow-hidden rounded-2xl"
+      className="group relative w-full overflow-hidden rounded-none sm:rounded-2xl"
     >
       <Link
         href={`/${locale}/content/${id}`}
         onClick={handleClick}
-        className="relative block overflow-hidden rounded-2xl border border-white/20 bg-[#0A0A0A] transition-[border-color,box-shadow] duration-300 hover:border-white/40 hover:shadow-lg hover:shadow-white/5"
+        className="relative block overflow-hidden rounded-none bg-[#0A0A0A] transition-[box-shadow] duration-300 hover:shadow-lg hover:shadow-white/5 sm:rounded-2xl"
       >
         {/* Image Section */}
         {imageUrl && imageUrl.trim() !== ''
@@ -281,16 +316,8 @@ export function ContentGridCard({
             )}
         {/* Content Section */}
         <div className="p-6">
-          {/* Category Tag and Date */}
-          <div className="mb-3 flex items-center justify-between gap-2">
-            {/* Category Badge - Left */}
-            <div className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1">
-              <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
-              <span className="text-xs font-medium tracking-wider text-white/70 uppercase">
-                {category}
-              </span>
-            </div>
-            {/* Date - Right */}
+          {/* Date */}
+          <div className="mb-3 flex items-center justify-end gap-2">
             {createdAt && (
               <span className="text-xs text-white/50">
                 {formatDate(createdAt)}
@@ -334,6 +361,29 @@ export function ContentGridCard({
         {/* Hover indicator */}
         <div className="absolute top-0 right-0 left-0 h-[2px] origin-left scale-x-0 rounded-t-2xl bg-linear-to-r from-blue-500 to-purple-500 transition-transform duration-300 group-hover:scale-x-100" />
       </Link>
+      <div className="border-t border-white/10 bg-[#0A0A0A] px-4 py-3 sm:px-6">
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={handlePlayClick}
+            className="inline-flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/85 transition-colors hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0A0A] focus-visible:outline-none"
+            aria-label={isPlaying ? 'Pause content' : 'Play content'}
+          >
+            {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+            <span>{isPlaying ? 'Pause' : 'Play'}</span>
+          </button>
+          <button
+            type="button"
+            onClick={handleShareClick}
+            className="inline-flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/85 transition-colors hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0A0A] focus-visible:outline-none"
+            aria-label="Share content"
+          >
+            <Share2 className="h-4 w-4" />
+            <span>Share</span>
+          </button>
+        </div>
+        <p aria-live="polite" className="sr-only">{shareMessage}</p>
+      </div>
     </motion.div>
   );
 }

--- a/src/components/content-grid-card.tsx
+++ b/src/components/content-grid-card.tsx
@@ -194,12 +194,12 @@ export function ContentGridCard({
               ease: MOTION.easing.default,
             }
       }
-      className="group relative flex h-full w-full flex-col overflow-hidden rounded-none sm:rounded-2xl"
+      className="group relative flex h-full w-full flex-col overflow-hidden rounded-none border border-white/5 transition-colors duration-300 sm:rounded-t-2xl sm:rounded-b-none group-hover:border-white/15"
     >
       <Link
         href={`/${locale}/content/${id}`}
         onClick={handleClick}
-        className="relative flex h-full flex-1 flex-col overflow-hidden rounded-none bg-[#0A0A0A] transition-[box-shadow] duration-300 hover:shadow-lg hover:shadow-white/5 sm:rounded-2xl"
+        className="relative flex h-full flex-1 flex-col overflow-hidden rounded-none bg-[#0A0A0A] transition-colors duration-300 group-hover:bg-[#101010] sm:rounded-t-2xl sm:rounded-b-none"
       >
         {/* Image Section */}
         {imageUrl && imageUrl.trim() !== ''
@@ -216,7 +216,7 @@ export function ContentGridCard({
                   loading={index < 4 ? 'eager' : 'lazy'}
                   quality={70}
                 />
-                <div className="absolute inset-0 bg-gradient-to-t from-[#0A0A0A] via-transparent to-transparent" />
+                <div className="absolute inset-0 bg-gradient-to-t from-[#0A0A0A] via-transparent to-transparent opacity-90 transition-opacity duration-300 group-hover:opacity-100" />
 
                 {/* Duration badge on image */}
                 {duration && (
@@ -341,7 +341,7 @@ export function ContentGridCard({
         {/* Hover indicator */}
         <div className="absolute top-0 right-0 left-0 h-[2px] origin-left scale-x-0 rounded-t-2xl bg-linear-to-r from-blue-500 to-purple-500 transition-transform duration-300 group-hover:scale-x-100" />
       </Link>
-      <div className="border-t border-white/10 bg-[#0A0A0A] px-4 py-3 sm:px-6">
+      <div className="border-t border-white/10 bg-[#0A0A0A] px-4 py-3 transition-colors duration-300 group-hover:bg-[#111111] sm:px-6">
         <div className="flex items-center justify-between gap-3">
           <button
             type="button"

--- a/src/components/content-grid-card.tsx
+++ b/src/components/content-grid-card.tsx
@@ -2,10 +2,10 @@
 
 import type { Track, VisibleQueueContext } from '@/types/audio';
 import { motion } from 'framer-motion';
-import { Clock, Pause, Play, Share2 } from 'lucide-react';
+import { Clock, Pause, Play } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { usePlaybackOptional } from '@/components/audio/playback-provider';
 import { useContentAnalytics } from '@/hooks/useContentAnalytics';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
@@ -22,6 +22,8 @@ type ContentGridCardProps = {
   category: string;
   duration?: number | null;
   createdAt?: string;
+  sourceName?: string | null;
+  sourceLink?: string | null;
   index?: number;
   locale: string;
   surface?: 'home' | 'dashboard';
@@ -35,6 +37,16 @@ type ContentGridCardProps = {
   allTracks?: Track[];
 };
 
+const decodeHtmlEntities = (value: string): string => {
+  if (typeof window === 'undefined') {
+    return value;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = value;
+  return textarea.value;
+};
+
 export function ContentGridCard({
   id,
   title,
@@ -44,6 +56,8 @@ export function ContentGridCard({
   category,
   duration,
   createdAt,
+  sourceName,
+  sourceLink,
   index = 0,
   locale,
   surface = 'home',
@@ -56,7 +70,7 @@ export function ContentGridCard({
   const { trackContentViewed, trackContentPlayStarted } = useContentAnalytics();
   const playback = usePlaybackOptional();
   const reducedMotion = useReducedMotion();
-  const [shareMessage, setShareMessage] = useState('');
+  const decodedSourceName = sourceName ? decodeHtmlEntities(sourceName) : null;
 
   // Check if this track is currently playing
   const isCurrentTrack = playback?.activeTrack?.id === id;
@@ -151,40 +165,6 @@ export function ContentGridCard({
     });
   };
 
-  const handleShareClick = useCallback(
-    async (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault();
-      e.stopPropagation();
-
-      const shareUrl = typeof window !== 'undefined'
-        ? `${window.location.origin}/${locale}/content/${id}`
-        : `/${locale}/content/${id}`;
-
-      try {
-        if (typeof navigator !== 'undefined' && navigator.share) {
-          await navigator.share({
-            title,
-            text: summary ?? title,
-            url: shareUrl,
-          });
-          setShareMessage('Shared successfully.');
-          return;
-        }
-
-        if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-          await navigator.clipboard.writeText(shareUrl);
-          setShareMessage('Link copied to clipboard.');
-          return;
-        }
-
-        setShareMessage('Sharing is not supported on this device.');
-      } catch {
-        setShareMessage('Could not share right now.');
-      }
-    },
-    [id, locale, summary, title],
-  );
-
   const handleClick = () => {
     trackContentViewed({
       user_id: userId,
@@ -214,12 +194,12 @@ export function ContentGridCard({
               ease: MOTION.easing.default,
             }
       }
-      className="group relative w-full overflow-hidden rounded-none sm:rounded-2xl"
+      className="group relative flex h-full w-full flex-col overflow-hidden rounded-none sm:rounded-2xl"
     >
       <Link
         href={`/${locale}/content/${id}`}
         onClick={handleClick}
-        className="relative block overflow-hidden rounded-none bg-[#0A0A0A] transition-[box-shadow] duration-300 hover:shadow-lg hover:shadow-white/5 sm:rounded-2xl"
+        className="relative flex h-full flex-1 flex-col overflow-hidden rounded-none bg-[#0A0A0A] transition-[box-shadow] duration-300 hover:shadow-lg hover:shadow-white/5 sm:rounded-2xl"
       >
         {/* Image Section */}
         {imageUrl && imageUrl.trim() !== ''
@@ -315,7 +295,7 @@ export function ContentGridCard({
               </div>
             )}
         {/* Content Section */}
-        <div className="p-6">
+        <div className="flex min-h-[220px] flex-1 flex-col p-6">
           {/* Date */}
           <div className="mb-3 flex items-center justify-end gap-2">
             {createdAt && (
@@ -331,7 +311,7 @@ export function ContentGridCard({
           </h3>
           {/* Summary */}
           {summary && (
-            <p className="line-clamp-3 text-sm leading-relaxed text-white/60">
+            <p className="line-clamp-4 text-sm leading-relaxed text-white/60">
               {summary}
             </p>
           )}
@@ -372,17 +352,24 @@ export function ContentGridCard({
             {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
             <span>{isPlaying ? 'Pause' : 'Play'}</span>
           </button>
-          <button
-            type="button"
-            onClick={handleShareClick}
-            className="inline-flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/85 transition-colors hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0A0A] focus-visible:outline-none"
-            aria-label="Share content"
-          >
-            <Share2 className="h-4 w-4" />
-            <span>Share</span>
-          </button>
+          {sourceLink && decodedSourceName
+            ? (
+                <a
+                  href={sourceLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-h-11 min-w-0 items-center rounded-lg px-3 py-2 text-sm font-medium text-white/85 transition-colors hover:bg-white/10 hover:text-white focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0A0A0A] focus-visible:outline-none"
+                  aria-label={`${decodedSourceName} (opens in new tab)`}
+                >
+                  <span className="block max-w-full truncate">{decodedSourceName}</span>
+                </a>
+              )
+            : (
+                <span className="inline-flex min-h-11 items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-white/50">
+                  <span>Source</span>
+                </span>
+              )}
         </div>
-        <p aria-live="polite" className="sr-only">{shareMessage}</p>
       </div>
     </motion.div>
   );

--- a/src/components/content-grid-discover.tsx
+++ b/src/components/content-grid-discover.tsx
@@ -17,6 +17,8 @@ type ContentItem = {
   duration: number | null;
   keyInsight: string[] | null;
   created_at: string;
+  sourceName: string | null;
+  sourceLink: string | null;
   audioUrl?: string | null;
 };
 
@@ -394,6 +396,7 @@ export function ContentGridDiscover({
                 <div
                   key={item.id}
                   className={cn(
+                    'h-full',
                     isFeatured
                       ? 'sm:col-span-2 lg:col-span-2'
                       : 'sm:col-span-1 lg:col-span-1',
@@ -408,6 +411,8 @@ export function ContentGridDiscover({
                     category={item.category}
                     duration={item.duration}
                     createdAt={item.created_at}
+                    sourceName={item.sourceName}
+                    sourceLink={item.sourceLink}
                     index={index}
                     locale={locale}
                     surface={surface}

--- a/src/libs/content-data.ts
+++ b/src/libs/content-data.ts
@@ -11,6 +11,8 @@ type ContentItem = {
   category: string;
   duration: number | null;
   created_at: string;
+  sourceName: string | null;
+  sourceLink: string | null;
   audioUrl?: string | null;
 };
 
@@ -43,6 +45,8 @@ export async function fetchCategorisedContent(): Promise<FetchContentResult> {
       key_insights,
       image_url,
       created_at,
+      source_name,
+      source_url,
       status,
       content_item_tags(
         categories(
@@ -100,6 +104,8 @@ export async function fetchCategorisedContent(): Promise<FetchContentResult> {
       created_at: item.created_at,
       category: categoryName,
       duration: audioFile.duration,
+      sourceName: item.source_name ?? null,
+      sourceLink: item.source_url ?? null,
       audioUrl: audioFile.file_url,
     };
 


### PR DESCRIPTION
### Motivation
- Make content cards edge-to-edge on small screens and remove the visible border to match the intended mobile layout while preserving rounded cards at `sm+` breakpoints. 
- Provide a compact, accessible footer that lets users add content to the player (and start playback) or share content without relying on the tag label UI.

### Description
- Removed the card border and applied edge-to-edge small-screen styling by changing the wrapper classes to `rounded-none sm:rounded-2xl` and removing the `border` styles in `src/components/content-grid-card.tsx`.
- Removed the category/tag badge from the card content area and left the date row above the title and summary in `ContentGridCard`.
- Added a footer action bar under the card with accessible `Play/Pause` and `Share` buttons, wired the Play button to the existing `playback.playTrack` behavior so the item is added to the queue and playback starts, and included ARIA focus-visible styles on the buttons.
- Implemented a native Web Share API flow with a clipboard fallback and polite screen-reader feedback via an `aria-live` message, and added `Share2` and `useState` imports to support the share UI and state.

### Testing
- Ran `npm run lint -- src/components/content-grid-card.tsx` which surfaced pre-existing repository warnings and one local formatting issue; the repo-wide warnings remain unrelated to this change. (lint reported errors/warnings)
- Ran `npx eslint src/components/content-grid-card.tsx --fix` which applied auto-fixes for the edited file successfully. (auto-fix succeeded)
- Changes were committed with message `Update content cards layout and add action footer` after lint autofix. (commit succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e00470a883279c901b515d2f5da6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Share content directly from cards with automatic platform detection and clipboard fallback
* New Play and Share action buttons added to content cards
* Enhanced card interface with creation date display and real-time share feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->