### PR TITLE
feat: remove iOS PWA install prompt popup

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,7 +8,7 @@ import { setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 
 import { PostHogProvider } from '@/components/analytics/PostHogProvider';
-import { IOSInstallPrompt, PWAProvider, PWAUpdateToast } from '@/components/pwa';
+import { PWAProvider, PWAUpdateToast } from '@/components/pwa';
 import { routing } from '@/libs/I18nRouting';
 import '@/styles/global.css';
 
@@ -100,7 +100,6 @@ export default async function RootLayout(props: {
               <SpeedInsights />
               <div>{props.children}</div>
               <PWAUpdateToast />
-              <IOSInstallPrompt />
             </PWAProvider>
           </PostHogProvider>
         </NextIntlClientProvider>


### PR DESCRIPTION
Removes the IOSInstallPrompt component from the root layout so the
"Install Speasy" bottom sheet no longer appears for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the iOS app installation prompt from the progressive web app setup flow to streamline user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->