### PR TITLE
perf: make content routes statically cacheable instead of dynamic-per-request

### DIFF
--- a/src/app/[locale]/(marketing)/category/[slug]/page.tsx
+++ b/src/app/[locale]/(marketing)/category/[slug]/page.tsx
@@ -3,7 +3,13 @@ import { getTranslations } from 'next-intl/server';
 import { ContentGridDiscover } from '@/components/content-grid-discover';
 import { fetchCategorisedContent } from '@/libs/content-data';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 300;
+
+// No paths pre-rendered at build time -- each slug is rendered on first
+// visit and then served from the ISR cache for `revalidate` seconds.
+export function generateStaticParams() {
+  return [];
+}
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: string; slug: string }>;
@@ -19,11 +25,8 @@ export async function generateMetadata(props: {
 
 export default async function CategoryPage(props: {
   params: Promise<{ locale: string; slug: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { locale, slug } = await props.params;
-  const searchParams = await props.searchParams;
-  const autoplay = searchParams.autoplay === 'true';
   const result = await fetchCategorisedContent();
 
   if (!result.ok) {
@@ -48,7 +51,6 @@ export default async function CategoryPage(props: {
         locale={locale}
         surface="home"
         initialCategory={slug}
-        autoplay={autoplay}
       />
     </div>
   );

--- a/src/app/[locale]/(marketing)/content/[id]/page.tsx
+++ b/src/app/[locale]/(marketing)/content/[id]/page.tsx
@@ -6,12 +6,18 @@ import { Footer } from '@/components/footer';
 import { fetchContentDetail } from '@/libs/content-data';
 import { Env } from '@/libs/Env';
 
-// Force dynamic rendering
-export const dynamic = 'force-dynamic';
+export const revalidate = 300;
 
 type ContentDetailProps = {
   params: Promise<{ id: string; locale: string }>;
 };
+
+// No paths pre-rendered at build time (content is created continuously by
+// the LLM pipeline) -- each id is rendered on first visit and then served
+// from the ISR cache for `revalidate` seconds.
+export function generateStaticParams() {
+  return [];
+}
 
 export async function generateMetadata(
   props: ContentDetailProps,

--- a/src/app/[locale]/(marketing)/latest/page.tsx
+++ b/src/app/[locale]/(marketing)/latest/page.tsx
@@ -18,11 +18,8 @@ export async function generateMetadata(props: {
 
 export default async function LatestPage(props: {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { locale } = await props.params;
-  const searchParams = await props.searchParams;
-  const autoplay = searchParams.autoplay === 'true';
   const result = await fetchCategorisedContent();
 
   if (!result.ok) {
@@ -47,7 +44,6 @@ export default async function LatestPage(props: {
         locale={locale}
         surface="home"
         initialCategory="latest"
-        autoplay={autoplay}
       />
     </div>
   );

--- a/src/app/[locale]/(marketing)/page.tsx
+++ b/src/app/[locale]/(marketing)/page.tsx
@@ -21,11 +21,8 @@ export async function generateMetadata(props: {
 
 export default async function HomePage(props: {
   params: Promise<{ locale: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { locale } = await props.params;
-  const searchParams = await props.searchParams;
-  const autoplay = searchParams.autoplay === 'true';
   const result = await fetchCategorisedContent();
 
   if (!result.ok) {
@@ -54,7 +51,6 @@ export default async function HomePage(props: {
         categories={result.categories}
         locale={locale}
         surface="home"
-        autoplay={autoplay}
       />
     </div>
   );

--- a/src/components/content-grid-discover.tsx
+++ b/src/components/content-grid-discover.tsx
@@ -2,7 +2,8 @@
 
 import type { Track, VisibleQueueContext } from '@/types/audio';
 import { Cpu, DollarSign, Palette, Star, Trophy } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePlaybackOptional } from '@/components/audio/playback-provider';
 import { cn } from '@/libs/utils';
 
@@ -34,7 +35,6 @@ type ContentGridDiscoverProps = {
   userId?: string;
   experimentVariant?: string;
   initialCategory?: string;
-  autoplay?: boolean;
 };
 
 // Map category names to icons
@@ -65,6 +65,37 @@ function buildTabPath(tabId: string): string {
   return tabId === 'latest' ? '/' : `/category/${tabId}`;
 }
 
+// Isolated so only this (invisible) subtree needs useSearchParams(), keeping
+// the rest of the grid statically renderable instead of forcing the whole
+// page dynamic just to read ?autoplay=true.
+function AutoplayFromUrl({
+  playback,
+  tracks,
+  queueContext,
+}: {
+  playback: ReturnType<typeof usePlaybackOptional>;
+  tracks: Track[];
+  queueContext: VisibleQueueContext;
+}) {
+  const searchParams = useSearchParams();
+  const autoplay = searchParams.get('autoplay') === 'true';
+  const hasAutoPlayed = useRef(false);
+
+  useEffect(() => {
+    if (!autoplay || hasAutoPlayed.current || !playback || tracks.length === 0) {
+      return;
+    }
+    hasAutoPlayed.current = true;
+    const firstTrack = tracks[0];
+    if (firstTrack) {
+      playback.playTrack(firstTrack.id, queueContext, tracks);
+      playback.openPlayer();
+    }
+  }, [autoplay, playback, tracks, queueContext]);
+
+  return null;
+}
+
 export function ContentGridDiscover({
   categories,
   locale,
@@ -72,7 +103,6 @@ export function ContentGridDiscover({
   userId,
   experimentVariant,
   initialCategory,
-  autoplay = false,
 }: ContentGridDiscoverProps) {
   const playback = usePlaybackOptional();
 
@@ -118,7 +148,6 @@ export function ContentGridDiscover({
     width: number;
   }>({ left: 0, width: 0 });
   const tabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
-  const hasAutoPlayed = useRef(false);
 
   const selectedTabData = tabs.find(tab => tab.id === selectedTab);
   const displayedItems = selectedTabData?.items || [];
@@ -186,19 +215,6 @@ export function ContentGridDiscover({
       }
     }
   }, [setSelectedCategoryId, setQueueContextFn, selectedTab, tracks, queueContext]);
-
-  // Handle autoplay from URL (once, when tracks become available)
-  useEffect(() => {
-    if (!autoplay || hasAutoPlayed.current || !playback || tracks.length === 0) {
-      return;
-    }
-    hasAutoPlayed.current = true;
-    const firstTrack = tracks[0];
-    if (firstTrack) {
-      playback.playTrack(firstTrack.id, queueContext, tracks);
-      playback.openPlayer();
-    }
-  }, [autoplay, playback, tracks, queueContext]);
 
   // Sync URL when tab changes (home surface only, shallow replaceState)
   const handleTabChange = useCallback(
@@ -289,6 +305,10 @@ export function ContentGridDiscover({
 
   return (
     <div className="space-y-8">
+      <Suspense fallback={null}>
+        <AutoplayFromUrl playback={playback} tracks={tracks} queueContext={queueContext} />
+      </Suspense>
+
       {/* Header */}
       <div className="mb-2">
         <h1 className="mb-3 font-serif text-5xl leading-tight text-white">


### PR DESCRIPTION
Follow-up to #84. That commit only cached the data fetch inside each render; the pages themselves still ran a full dynamic render on every request (`/category/[slug]` and `/content/[id]` were `force-dynamic`, and `/` and `/latest` read `searchParams`, which defeats their `revalidate` config). Vercel was still invoking a function and doing a full React render on every single hit to the four highest-traffic routes, so Fluid Active CPU and ISR weren't actually benefiting from the earlier fix.

- Move the `?autoplay=true` read out of the server pages and into a small Suspense-wrapped subcomponent inside the already-client-side `ContentGridDiscover`, so reading it no longer forces the whole page (and its visible content) into dynamic rendering
- Replace `force-dynamic` with `revalidate = 300` on `/category/[slug]` and `/content/[id]`, with an empty `generateStaticParams()` so both register for on-demand ISR (render once per path, cache for 5 min) instead of being excluded from the prerender manifest entirely
- Verified via `.next/prerender-manifest.json`, not just the build summary table: all four routes are now static/ISR-backed

## Test plan
- [x] `pnpm run lint` / `check:types` clean on touched files (pre-existing unrelated failures on `main` left untouched)
- [x] `pnpm test` — same 20/20 unit tests passing as before
- [x] `pnpm run build-local` — confirmed via `.next/prerender-manifest.json` that `/`, `/latest`, `/category/[slug]`, `/content/[id]` are all registered as static/ISR routes
- [ ] Manually verify `?autoplay=true` still auto-plays the first track on `/`, `/latest`, and a category page in a running app

---
_Generated by [Claude Code](https://claude.ai/code/session_019DbbRrGx3kSGMiP8wYr1gZ)_